### PR TITLE
Fj 7/what is left to fix

### DIFF
--- a/nc/templates/nc.html
+++ b/nc/templates/nc.html
@@ -1,6 +1,6 @@
 {% extends 'state.html' %}
 
-{% load staticfiles bootstrap3 humanize %}
+{% load static bootstrap3 humanize %}
 
 {% block state-name %}
   North Carolina

--- a/nc/templates/nc/agency_detail.html
+++ b/nc/templates/nc/agency_detail.html
@@ -1,6 +1,6 @@
 {% extends "agency_detail.html" %}
 
-{% load static from staticfiles %}
+{% load static %}
 
 {% block agency-list-url %}{% url 'nc:agency-list' %}{% endblock agency-list-url %}
 

--- a/requirements/base/base.in
+++ b/requirements/base/base.in
@@ -1,5 +1,5 @@
 # base requirements.in
-django<3.0
+django>2.2,<3.0
 celery
 census
 us

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -21,7 +21,7 @@ django-el-pagination==3.3.0  # via -r requirements/base/base.in
 django-extensions==3.0.1  # via -r requirements/base/base.in
 django-memoize==2.3.1     # via -r requirements/base/base.in
 django-selectable==1.3.0  # via -r requirements/base/base.in
-django==2.2.14            # via -r requirements/base/base.in, django-bootstrap3, django-el-pagination, django-memoize, djangorestframework
+django==2.2.15            # via -r requirements/base/base.in, django-bootstrap3, django-el-pagination, django-memoize, djangorestframework
 djangorestframework==3.11.0  # via -r requirements/base/base.in, drf-extensions
 drf-extensions==0.6.0     # via -r requirements/base/base.in
 future==0.18.2            # via celery, census

--- a/requirements/deploy/deploy.txt
+++ b/requirements/deploy/deploy.txt
@@ -6,7 +6,7 @@
 #
 certifi==2020.6.20        # via -c requirements/deploy/../base/base.txt, sentry-sdk
 django-redis==4.12.1      # via -r requirements/deploy/deploy.in
-django==2.2.14            # via -c requirements/deploy/../base/base.txt, django-redis
+django==2.2.15            # via -c requirements/deploy/../base/base.txt, django-redis
 newrelic==5.12.1.141      # via -r requirements/deploy/deploy.in
 python3-memcached==1.51   # via -r requirements/deploy/deploy.in
 pytz==2019.3              # via -c requirements/deploy/../base/base.txt, django

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -25,7 +25,7 @@ cryptography==2.9         # via ansible
 decorator==4.4.2          # via ipython, traitlets
 dictdiffer==0.8.1         # via openshift
 django-debug-toolbar==2.2  # via -r requirements/dev/dev.in
-django==2.2.14            # via -c requirements/dev/../base/base.txt, django-debug-toolbar
+django==2.2.15            # via -c requirements/dev/../base/base.txt, django-debug-toolbar
 docutils==0.15.2          # via awscli, botocore, rstcheck, sphinx
 flake8==3.8.3             # via -r requirements/dev/dev.in
 google-auth==1.14.3       # via kubernetes

--- a/traffic_stops/templates/agency_detail.html
+++ b/traffic_stops/templates/agency_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load humanize %}
-{% load static from staticfiles %}
+{% load static  %}
 
 {% block title %}
   {{block.super}} | {{object}}

--- a/traffic_stops/templates/agency_list.html
+++ b/traffic_stops/templates/agency_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% load selectable_tags staticfiles %}
+{% load selectable_tags static %}
 
 {% block pre-content %}
 <div class="state-banner affix-offset-top-pos agency-list">

--- a/traffic_stops/templates/base.html
+++ b/traffic_stops/templates/base.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en" class="no-js">
 <head>

--- a/traffic_stops/templates/home.html
+++ b/traffic_stops/templates/home.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static%}
 
 {% block body_id %}home{% endblock %}
 {% block body_class %}navbar-inverse{% endblock %}

--- a/traffic_stops/templates/includes/navigation.html
+++ b/traffic_stops/templates/includes/navigation.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 <div class="navbar navbar-default navbar-fixed-top affix-offset-top-neg odp-nav {% if navbar_inverse %}navbar-inverse{% endif %}" role="navigation">
   <div id="content" class="container">

--- a/traffic_stops/templates/state.html
+++ b/traffic_stops/templates/state.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load selectable_tags staticfiles %}
+{% load selectable_tags static %}
 
 {% block body_id %}state{% endblock %}
 


### PR DESCRIPTION
This was branched off of FJ-5, so that will need to be merged first. Changes `{% load staticfiles %}` to `{% load static %}` in advance of 3.0 deprecation.