### PR TITLE
[FJ-20] 2018 5-Year ACS Data

### DIFF
--- a/nc/templates/nc/agency_detail.html
+++ b/nc/templates/nc/agency_detail.html
@@ -12,36 +12,41 @@
 
 {% block census-display %}
   <!-- census data -->
-  <div id="census_row" class="row optional">
-    <div class="col-md-12 headline">
-      <h2>ACS Census Data (2012 - 2016)<a class="anchor-offset" id="demographics"></a></h2>
-    </div>
+  <div id="census_row" class="chart-row row optional">
+    <div class="brand-lines"></div>
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12 headline">
+          <h2>ACS Census Data (2014 - 2018)<a class="anchor-offset" id="demographics"></a></h2>
+        </div>
 
 
-    <div class="col-md-12">
-      <h3>Local Population (percentage by race/ethnic composition)</h3>
+        <div class="col-md-12">
+          <h3>Local Population (percentage by race/ethnic composition)</h3>
 
-      <p class="help-block">
-        This graph reflects the race/ethnic composition of the jurisdiction at the time of the most recent survey by the Census Bureau. It is included for comparative purposes. The actual local driving population within a given jurisdiction may vary significantly from census figures.
-      </p>
-    </div>
+          <p class="help-block">
+            This graph reflects the race/ethnic composition of the jurisdiction at the time of the most recent survey by the Census Bureau. It is included for comparative purposes. The actual local driving population within a given jurisdiction may vary significantly from census figures.
+          </p>
+        </div>
 
-    <div class="col-md-4">
-      <div class="pie-chart-container">
-        <svg id="census_pie"></svg>
+        <div class="col-md-4">
+          <div class="pie-chart-container">
+            <svg id="census_pie"></svg>
+          </div>
+          <p class="graph-help-block">
+            * Non-hispanic
+          </p>
+        </div>
+
+        <div class="col-md-8">
+          <h3>Tabular view of census data</h3>
+          <br><br>
+          <div id="census_data"></div>
+          <p class="graph-help-block">
+            * Non-hispanic
+          </p>
+        </div>
       </div>
-      <p class="graph-help-block">
-        * Non-hispanic
-      </p>
-    </div>
-
-    <div class="col-md-8">
-      <h3>Tabular view of census data</h3>
-      <br><br>
-      <div id="census_data"></div>
-      <p class="graph-help-block">
-        * Non-hispanic
-      </p>
     </div>
   </div>
 {% endblock census-display %}

--- a/tsdata/acs.py
+++ b/tsdata/acs.py
@@ -51,12 +51,12 @@ RACE_VARIABLES = {
 class ACS(object):
     """Base class to call ACS API and normalize output"""
 
-    source = "ACS 5-Year Data (2012-2016)"
+    source = "ACS 5-Year Data (2014-2018)"
     geography = None
     drop_columns = None
 
     def __init__(self, key, state_abbr):
-        self.api = census.Census(key, year=2016)
+        self.api = census.Census(key, year=2018)
         self.fips = getattr(states, state_abbr).fips
         self.state_abbr = state_abbr
 

--- a/tsdata/management/commands/import_census.py
+++ b/tsdata/management/commands/import_census.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from tsdata import acs
 
-ACS_JSON_URL = "https://s3-us-west-2.amazonaws.com/openpolicingdata/acs-2016.json"
+ACS_JSON_URL = "https://nccopwatch.s3.us-east-2.amazonaws.com/acs-2018.json"
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
https://caktus.atlassian.net/browse/FJ-20

Turns out the Python library supports 2018 data, so the update was pretty straightforward:
* Use 2018 5-Year ACS data
* Upload compiled JSON data to S3 bucket
* Update census display to use new row formatting 

To test, run:

* ``python manage.py import_census``
* Confirm census data is on Durham agency page: http://localhost:8000/agency/80/
* Confirm Durham data matches [2018 ACS 5-Year data on data.census.gov](https://data.census.gov/cedsci/table?g=1600000US3719000&d=ACS%205-Year%20Estimates%20Data%20Profiles&tid=ACSDP5Y2018.DP05&moe=false&tp=false&hidePreview=true):
    * HISPANIC OR LATINO AND RACE -> Total population
        * Not Hispanic or Latino
            * **White**
            * **Black**
            * **Native America**
            * **Asian**
            * **Other** (combination of Native Hawaiian, Some other race alone, Two or more races)
        * **Hispanic or Latino (of any race)**