### PR TITLE
[FJ-41] Simple Social Share

### DIFF
--- a/nc/templates/nc/agency_detail.html
+++ b/nc/templates/nc/agency_detail.html
@@ -2,6 +2,14 @@
 
 {% load static %}
 
+{% block extra-meta %}
+  {{ block.super }}
+  <meta property="og:title" content="Traffic Stop Data for {% if officer_id %} Officer {% endif %}{{ object }}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="{{ request.build_absolute_uri }}" />
+  <meta property="og:image" content="{{ request.scheme }}://{{ request.get_host}}{% static 'img/NC_copwatch_logo.png' %}" />
+{% endblock %}
+
 {% block agency-list-url %}{% url 'nc:agency-list' %}{% endblock agency-list-url %}
 
 {% block search-url %}{% url 'nc:stops-search' %}{% endblock search-url %}


### PR DESCRIPTION
adds opengraph meta tags to agency_detail for testing
This isn't the final PR, but it does need to go to staging to test. 

Also, there's a bit of a problem with testing it. We'll need to disable basic auth so that we can test the OG elements in social media.