### PR TITLE
[FJ-46] Copy agencies in using correct file during import

### DIFF
--- a/nc/data/copy_nc.py
+++ b/nc/data/copy_nc.py
@@ -21,8 +21,9 @@ NC_COPY_INSTRUCTIONS = {
     "Search.csv": "COPY nc_search (search_id, stop_id, person_id, type, vehicle_search, driver_search, passenger_search, property_search, vehicle_siezed, personal_property_siezed, other_property_sized) FROM STDIN WITH DELIMITER ',' NULL AS '' CSV HEADER",
     "Contraband.csv": "COPY nc_contraband (contraband_id, search_id, person_id, stop_id, ounces, pounds, pints, gallons, dosages, grams, kilos, money, weapons, dollar_amount) FROM STDIN WITH DELIMITER ',' CSV HEADER",
     "SearchBasis.csv": "COPY nc_searchbasis (search_basis_id, search_id, person_id, stop_id, basis) FROM STDIN WITH DELIMITER ',' CSV HEADER",
-    "NC_agencies.csv": "COPY  nc_agency (id, name, census_profile_id) FROM STDIN WITH DELIMITER ',' CSV HEADER FORCE NOT NULL census_profile_id",
 }  # noqa
+
+NC_AGENCY_COPY_INSTRUCTIONS = "COPY nc_agency (id, name, census_profile_id) FROM STDIN WITH DELIMITER ',' CSV HEADER FORCE NOT NULL census_profile_id"
 
 FINALIZE_COPY = """
     UPDATE nc_stop SET agency_id = nc_agency.id FROM nc_agency WHERE nc_stop.agency_description = nc_agency.name;

--- a/nc/data/importer.py
+++ b/nc/data/importer.py
@@ -281,6 +281,12 @@ def copy_from(destination, nc_csv_path):
         set_time_zone(cur, settings.NC_TIME_ZONE)
         logger.info("Truncating tables")
         cur.execute(copy_nc.CLEAN_DATABASE)
+        # agencies
+        agency_path = Path(nc_csv_path)
+        with agency_path.open() as fh:
+            logger.info(f"COPY {nc_csv_path} into the database")
+            cur.copy_expert(copy_nc.NC_AGENCY_COPY_INSTRUCTIONS, fh)
+        # datasets
         path = Path(destination)
         for p in path.glob("*.csv"):
             if p.name in copy_nc.NC_COPY_INSTRUCTIONS.keys():


### PR DESCRIPTION
https://caktus.atlassian.net/browse/FJ-46

This update fixes an import bug (during our refactor late last year, I believe) that prevented agency loading when **no new agencies** were discovered in the data file. In this case, rather than pointing to an importer-generated file `<import location>/NC_agencies.csv`, the existing file in `nc/data/NC_agencies.csv` should be referenced.

I've tested this locally using both import methods and confirmed it's working.
