### PR TITLE
[FJ-100] Filter NC stops using NC timezone

### DIFF
--- a/nc/data/timezones.ipynb
+++ b/nc/data/timezones.ipynb
@@ -1,0 +1,280 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "jewish-location",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setup Notebook to load Django code\n",
+    "# From project root, run: jupyter-lab\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "os.chdir('../..')\n",
+    "\n",
+    "import django\n",
+    "django.setup()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "early-preserve",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datetime as dt\n",
+    "import pytz\n",
+    "\n",
+    "from django.utils import timezone\n",
+    "from django.test import override_settings\n",
+    "\n",
+    "from nc.models import Stop, Person, Agency"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "excessive-broadcast",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-02-11 14:07:54,148 caching              DEBUG    cache hit: 7c97264763d28c00510b2512843c6df1\n"
+     ]
+    }
+   ],
+   "source": [
+    "durham = Agency.objects.get(pk=80)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "under-wiring",
+   "metadata": {},
+   "source": [
+    "# Raw Stops from Stop.csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "destroyed-greeting",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "26280425,Durham Police Department,2020-07-31 20:26:00.000,6,3,0,0,0,0,0,0,0,1168,32,\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 7/31, 8:26p ET\n",
+    "! grep 26280425 ncdata/Stop.csv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "respected-excellence",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "26351840,Durham Police Department,2020-08-01 02:25:00.000,5,1,0,0,0,0,0,0,0,1260,32,\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 8/1, 2:25a ET\n",
+    "! grep 26351840 ncdata/Stop.csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "prospective-bloom",
+   "metadata": {},
+   "source": [
+    "# UTC date filter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "cultural-failing",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2020, 8, 1, 0, 0, tzinfo=<UTC>)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "utc = pytz.timezone(\"UTC\")\n",
+    "start_date_utc = utc.localize(dt.datetime(2020, 8, 1))\n",
+    "start_date_utc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "fifth-daisy",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(26280425, datetime.datetime(2020, 8, 1, 0, 26, tzinfo=<UTC>))"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stop_utc = Stop.objects.no_cache().filter(agency=durham, date__gt=start_date_utc).order_by(\"date\").first()\n",
+    "stop_utc.stop_id, stop_utc.date"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "imperial-variation",
+   "metadata": {},
+   "source": [
+    "# America/New_York date filter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "extraordinary-receipt",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nyc = pytz.timezone(\"America/New_York\")\n",
+    "start_date_nyc = nyc.localize(dt.datetime(2020, 8, 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "alpine-peace",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(26351840, datetime.datetime(2020, 8, 1, 6, 25, tzinfo=<UTC>))"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stop_nyc = Stop.objects.no_cache().filter(agency=durham, date__gt=start_date_nyc).order_by(\"date\").first()\n",
+    "stop_nyc.stop_id, stop_nyc.date"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "union-disability",
+   "metadata": {},
+   "source": [
+    "# Django's localtime and TIME_ZONE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "acoustic-period",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2020, 8, 1, 0, 26, tzinfo=<UTC>)"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with override_settings(TIME_ZONE='UTC'):\n",
+    "    date = timezone.localtime(stop_utc.date)\n",
+    "date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "empty-harbor",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2020, 7, 31, 20, 26, tzinfo=<DstTzInfo 'America/New_York' EDT-1 day, 20:00:00 DST>)"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with override_settings(TIME_ZONE=\"America/New_York\"):\n",
+    "    date = timezone.localtime(stop_utc.date)\n",
+    "date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "wooden-prefix",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/nc/serializers.py
+++ b/nc/serializers.py
@@ -33,10 +33,12 @@ class PersonStopSerializer(serializers.ModelSerializer):
     officer_id = serializers.SerializerMethodField()
     stop_purpose = serializers.SerializerMethodField()
     stop_action = serializers.SerializerMethodField()
+    stop_id = serializers.SerializerMethodField()
 
     class Meta:
         model = stops.Person
         fields = (
+            "stop_id",
             "person_id",
             "date",
             "gender",
@@ -67,6 +69,9 @@ class PersonStopSerializer(serializers.ModelSerializer):
 
     def get_stop_action(self, obj):
         return obj.stop.get_action_display()
+
+    def get_stop_id(self, obj):
+        return obj.stop.stop_id
 
 
 class TopAgencyFactsSerializer(serializers.ModelSerializer):

--- a/nc/tests/api/test_basic_search.py
+++ b/nc/tests/api/test_basic_search.py
@@ -24,6 +24,7 @@ def test_response_person_fields(client, search_url, durham):
     response = client.get(search_url, data={"agency": durham.pk}, format="json")
     result = response.data["results"][0]
     expected = {
+        "stop_id": person.stop.stop_id,
         "person_id": person.person_id,
         "date": person.stop.date,
         "gender": person.get_gender_display(),

--- a/nc/tests/api/test_timezones.py
+++ b/nc/tests/api/test_timezones.py
@@ -1,0 +1,42 @@
+import datetime as dt
+
+import pytest
+import pytz
+from django.conf import settings
+from nc.tests import factories
+
+pytestmark = pytest.mark.django_db
+nc_timezone = pytz.timezone(settings.NC_TIME_ZONE)
+
+
+@pytest.fixture
+def july_person(durham):
+    stop_date = nc_timezone.localize(dt.datetime(2020, 7, 31, 20, 26))
+    return factories.PersonFactory(stop__agency=durham, stop__date=stop_date)
+
+
+@pytest.fixture
+def august_person(durham):
+    stop_date = nc_timezone.localize(dt.datetime(2020, 8, 1, 1, 15))
+    return factories.PersonFactory(stop__agency=durham, stop__date=stop_date)
+
+
+def test_stop_date_after_august_excludes_july_stop(client, search_url, durham, july_person):
+    response = client.get(
+        search_url,
+        data={"agency": durham.pk, "stop_date_after": dt.date(2020, 8, 1)},
+        format="json",
+    )
+    stop_ids = set([stop["stop_id"] for stop in response.data["results"]])
+    assert july_person.stop.stop_id not in stop_ids
+
+
+def test_stop_date_after_august_includes_august_stop(client, search_url, durham, august_person):
+    response = client.get(
+        search_url,
+        data={"agency": durham.pk, "stop_date_after": dt.date(2020, 8, 1)},
+        format="json",
+    )
+    stop_ids = set([stop["stop_id"] for stop in response.data["results"]])
+    assert {august_person.stop.stop_id} == stop_ids
+    assert august_person.stop.date == response.data["results"][0]["date"]

--- a/nc/tests/api/test_timezones.py
+++ b/nc/tests/api/test_timezones.py
@@ -40,3 +40,14 @@ def test_stop_date_after_august_includes_august_stop(client, search_url, durham,
     stop_ids = set([stop["stop_id"] for stop in response.data["results"]])
     assert {august_person.stop.stop_id} == stop_ids
     assert august_person.stop.date == response.data["results"][0]["date"]
+
+
+def test_stop_date_after_july_includes_both(client, search_url, durham, july_person, august_person):
+    response = client.get(
+        search_url,
+        data={"agency": durham.pk, "stop_date_after": dt.date(2020, 7, 1)},
+        format="json",
+    )
+    stop_ids = set([stop["stop_id"] for stop in response.data["results"]])
+    assert july_person.stop.stop_id in stop_ids
+    assert august_person.stop.stop_id in stop_ids

--- a/traffic_stops/settings/base.py
+++ b/traffic_stops/settings/base.py
@@ -60,7 +60,7 @@ DATABASE_ETL_USER = ""
 # timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = "UTC"
+TIME_ZONE = "America/New_York"
 NC_TIME_ZONE = "America/New_York"
 
 NC_KEY = "nc"


### PR DESCRIPTION
https://caktus.atlassian.net/browse/FJ-100

The bug was that since the default `TIME_ZONE` was `UTC`, the API would parse `stop_date` as `UTC` and filter stops using this time zone.

So, for example, if the frontend client requests `{stop_date_after: "2020-08-01"}`:
* The API constructs a datetime as `UTC`:
    * `datetime.datetime(2020, 8, 1, 0, 0, tzinfo=<UTC>)`
* This datetime represented in `America/New_York` is:
    * `datetime.datetime(2020, 7, 31, 20, 0, tzinfo=<DstTzInfo 'America/New_York' EDT-1 day, 20:00:00 DST>)`
* So when filtering Stops by date, which are stored as offsets from UTC, results from July 31st 8p ET (aka 8/1 12p UTC) and later are returned.

Setting `TIME_ZONE = "America/New_York"` makes the most sense since only NC stops are included now on NC CopWatch and guarantees the API will construct a date in the correct timezone for filtering.