### PR TITLE
[SEC-174] Point to proper IAM role name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,10 @@
-NC Traffic Stops
+NC CopWatch
 ================
 
-.. image:: https://badge.waffle.io/OpenDataPolicingNC/Traffic-Stops.svg?label=ready&title=Ready 
- :target: https://waffle.io/OpenDataPolicingNC/Traffic-Stops 
- :alt: 'Stories in Ready'
+.. image:: https://circleci.com/gh/caktus/Traffic-Stops.svg?style=svg
+    :target: https://circleci.com/gh/caktus/Traffic-Stops
 
-.. image:: https://readthedocs.org/projects/nc-traffic-stops/badge/?version=latest
-  :target: http://nc-traffic-stops.readthedocs.org/en/latest/
-  :alt: Documentation Status
-
-.. image:: https://travis-ci.org/OpenDataPolicingNC/Traffic-Stops.svg?branch=master
-    :target: https://travis-ci.org/OpenDataPolicingNC/Traffic-Stops
-
-NC Traffic Stops is a website to monitor and identify racial profiling
+NC CopWatch is a website to monitor and identify racial profiling
 practices by North Carolina law enforcement agencies. This project is lead by
 `Forward Justice`_, a nonpartisan law, policy, and strategy center dedicated to advancing racial, 
 social, and economic justice in the U.S. South.
@@ -20,6 +12,4 @@ social, and economic justice in the U.S. South.
 Please see the `production documentation`_ and `development documentation`_
 for more information.
 
-.. _production documentation: http://nc-traffic-stops.readthedocs.org/en/latest/
-.. _development documentation: http://nc-traffic-stops.readthedocs.org/en/dev/
 .. _Forward Justice: https://forwardjustice.org/

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -14,7 +14,7 @@ Caktus AWS Access
     .. code-block::
 
         [trafficstops]
-        role_arn = arn:aws:iam::000000000000:role/CaktusAccessRole
+        role_arn = arn:aws:iam::000000000000:role/CaktusAccountAccessRole-Admins
         source_profile = caktus
 
     See LastPass entry *Traffic Stops AWS Profile role_arn* for the AWS account
@@ -111,4 +111,3 @@ Deploy application
 4. Deploy::
 
     inv staging deploy --tag=...
-=======


### PR DESCRIPTION
Per [SEC-174](https://caktus.atlassian.net/browse/SEC-174), update reference to IAM role in docs to match [aws-assumerole](https://github.com/caktus/caktus-hosting-services/blob/main/docs/aws-assumerole.md#aws-accounts)