### PR TITLE
[FJ-136] More prominent loading

### DIFF
--- a/frontend/src/Components/Charts/ChartPrimitives/Bar.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/Bar.js
@@ -2,10 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { VictoryAxis, VictoryBar, VictoryChart, VictoryContainer } from 'victory';
 import { AXIS_STYLE } from './chartConstants';
+import ChartLoading from 'Components/Charts/ChartPrimitives/ChartLoading';
 import BarSkeleton from 'Components/Elements/Skeletons/BarSkeleton';
 
 function Bar({ data, chartProps, xAxisProps, yAxisProps, barProps }) {
-  if (!data) return <BarSkeleton />;
+  if (!data) return <ChartLoading skeleton={BarSkeleton} />;
   return (
     <VictoryChart
       {...chartProps}

--- a/frontend/src/Components/Charts/ChartPrimitives/ChartBase.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/ChartBase.js
@@ -2,9 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { ChartBaseStyled } from './ChartBase.styled';
 
 // Children
-import PieSkeleton from 'Components/Elements/Skeletons/PieSkeleton';
 import ResponsiveChartContainer from 'Components/Charts/ResponsiveChartContainer.styled';
 import Legend from 'Components/Charts/ChartPrimitives/Legend/Legend';
+import DataLoading from 'Components/Charts/ChartPrimitives/DataLoading';
 
 function ChartBase({
   children,
@@ -60,7 +60,7 @@ function ChartBase({
       {...props}
     >
       {hasError && <p>some chart error message</p>}
-      {isLoading && <PieSkeleton />}
+      {isLoading && <DataLoading />}
       <h2>{chartTitle}</h2>
       {!hideLegend && (
         <Legend

--- a/frontend/src/Components/Charts/ChartPrimitives/ChartLoading.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/ChartLoading.js
@@ -1,16 +1,18 @@
 import React from 'react';
-import { ChartLoadingStyled } from './ChartLoading.styled';
+import * as S from './ChartLoading.styled';
 
-function ChartLoading({ pastDelay }) {
-  if (pastDelay) {
-    return (
-      <ChartLoadingStyled>
-        <p>ChartLoading</p>
-      </ChartLoadingStyled>
-    );
-  } else {
-    return null;
-  }
+// Hooks
+import useOfficerId from 'Hooks/useOfficerId';
+
+function ChartLoading({ skeleton: Skeleton }) {
+  const officerId = useOfficerId();
+
+  return (
+    <S.ChartLoading>
+      <h3>Loading {officerId ? "Officer" : "Agency"} data...</h3>
+      <Skeleton scale={2} />
+    </S.ChartLoading>
+  );
 }
 
 export default ChartLoading;

--- a/frontend/src/Components/Charts/ChartPrimitives/DataLoading.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/DataLoading.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { DataLoadingStyled } from './DataLoading.styled';
+
+// Hooks
+import useOfficerId from 'Hooks/useOfficerId';
+
+// Children
+import PieSkeleton from 'Components/Elements/Skeletons/PieSkeleton';
+
+function DataLoading() {
+  const officerId = useOfficerId();
+
+  return (
+    <DataLoadingStyled>
+      <h3>Loading {officerId ? "Officer" : "Agency"} data...</h3>
+      <PieSkeleton scale={2} />
+    </DataLoadingStyled>
+  );
+}
+
+export default DataLoading;

--- a/frontend/src/Components/Charts/ChartPrimitives/DataLoading.styled.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/DataLoading.styled.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const ChartLoading = styled.div`
+export const DataLoadingStyled = styled.div`
   padding: 2rem 0;
   h3 {
     text-align: center;

--- a/frontend/src/Components/Charts/ChartPrimitives/GroupedBar.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/GroupedBar.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { VictoryChart, VictoryGroup, VictoryBar, VictoryAxis, VictoryContainer } from 'victory';
 import { AXIS_STYLE } from './chartConstants';
+import ChartLoading from 'Components/Charts/ChartPrimitives/ChartLoading';
 import BarSkeleton from 'Components/Elements/Skeletons/BarSkeleton';
 
 function GroupedBar({
@@ -16,7 +17,7 @@ function GroupedBar({
   iAxisProps,
   barProps,
 }) {
-  if (loading) return <BarSkeleton />;
+  if (loading) return <ChartLoading skeleton={BarSkeleton} />
 
   return (
     <VictoryChart

--- a/frontend/src/Components/Charts/ChartPrimitives/Line.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/Line.js
@@ -5,6 +5,7 @@ import { AXIS_STYLE } from './chartConstants';
 
 // Deps
 import { VictoryChart, VictoryLine, VictoryAxis, VictoryContainer } from 'victory';
+import ChartLoading from 'Components/Charts/ChartPrimitives/ChartLoading';
 import BarSkeleton from 'Components/Elements/Skeletons/BarSkeleton';
 
 function Line({
@@ -17,7 +18,7 @@ function Line({
   dAxisProps = {},
   iAxisProps = {},
 }) {
-  if (loading) return <BarSkeleton />;
+  if (loading) return <ChartLoading skeleton={BarSkeleton} />
 
   return (
     <VictoryChart containerComponent={<VictoryContainer style={{ touchAction: 'auto' }} />}>

--- a/frontend/src/Components/Charts/ChartPrimitives/Pie.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/Pie.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { useTheme } from 'styled-components';
 
 // Elements
+import ChartLoading from 'Components/Charts/ChartPrimitives/ChartLoading'
 import PieSkeleton from 'Components/Elements/Skeletons/PieSkeleton';
 import { VictoryPie, VictoryLabel, VictoryTooltip } from 'victory';
 import { P, WEIGHTS } from 'styles/StyledComponents/Typography';
@@ -23,7 +24,7 @@ function Pie({ data, loading }) {
     return d.length === 0 || d.every((dt) => dt.y === 0);
   };
 
-  if (loading) return <PieSkeleton />;
+  if (loading) return <ChartLoading skeleton={PieSkeleton} />;
 
   if (_dataIsZeros(data)) {
     return (

--- a/frontend/src/Components/Charts/ChartPrimitives/StackedBar.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/StackedBar.js
@@ -4,11 +4,12 @@ import PropTypes from 'prop-types';
 import { VictoryChart, VictoryStack, VictoryBar, VictoryAxis, VictoryContainer } from 'victory';
 import { AXIS_STYLE } from './chartConstants';
 
-// Childre
+// Children
+import ChartLoading from 'Components/Charts/ChartPrimitives/ChartLoading';
 import BarSkeleton from 'Components/Elements/Skeletons/BarSkeleton';
 
 function StackedBar({ data, loading, tickValues }) {
-  if (loading) return <BarSkeleton />;
+  if (loading) return <ChartLoading skeleton={BarSkeleton} />
 
   return (
     <VictoryChart

--- a/frontend/src/Components/Charts/ChartRoutes.js
+++ b/frontend/src/Components/Charts/ChartRoutes.js
@@ -6,8 +6,9 @@ import { Switch, useRouteMatch } from 'react-router-dom';
 import * as slugs from 'Routes/slugs';
 
 // Children
-import PieSkeleton from 'Components/Elements/Skeletons/PieSkeleton';
+// import PieSkeleton from 'Components/Elements/Skeletons/PieSkeleton';
 import ChartError from 'Components/Elements/ChartError';
+import DataLoading from 'Components/Charts/ChartPrimitives/DataLoading';
 
 function Charts() {
   const match = useRouteMatch();
@@ -24,7 +25,7 @@ function Charts() {
         importComponent={() =>
           import(/* webpackChunkName: 'Overview' */ 'Components/Charts/Overview/Overview')
         }
-        renderLoading={() => <PieSkeleton />}
+        renderLoading={() => <DataLoading />}
         renderError={() => <ChartError chartName="Overview" />}
       />
       <AsyncRoute
@@ -35,7 +36,7 @@ function Charts() {
             /* webpackChunkName: 'TrafficStops' */ 'Components/Charts/TrafficStops/TrafficStops'
           )
         }
-        renderLoading={() => <PieSkeleton />}
+        renderLoading={() => <DataLoading />}
         renderError={() => <ChartError chartName="Traffic Stops" />}
       />
       <AsyncRoute
@@ -43,7 +44,7 @@ function Charts() {
         importComponent={() =>
           import(/* webpackChunkName: 'Searches' */ 'Components/Charts/Searches/Searches')
         }
-        renderLoading={() => <PieSkeleton />}
+        renderLoading={() => <DataLoading />}
         renderError={() => <ChartError chartName="Searches" />}
       />
       <AsyncRoute
@@ -51,7 +52,7 @@ function Charts() {
         importComponent={() =>
           import(/* webpackChunkName: 'SearchRate' */ 'Components/Charts/SearchRate/SearchRate')
         }
-        renderLoading={() => <PieSkeleton />}
+        renderLoading={() => <DataLoading />}
         renderError={() => <ChartError chartName="Search Rate" />}
       />
       <AsyncRoute
@@ -59,7 +60,7 @@ function Charts() {
         importComponent={() =>
           import(/* webpackChunkName: 'Contraband' */ 'Components/Charts/Contraband/Contraband')
         }
-        renderLoading={() => <PieSkeleton />}
+        renderLoading={() => <DataLoading />}
         renderError={() => <ChartError chartName="Contraband" />}
       />
 
@@ -68,7 +69,7 @@ function Charts() {
         importComponent={() =>
           import(/* webpackChunkName: 'UseOfForce' */ 'Components/Charts/UseOfForce/UseOfForce')
         }
-        renderLoading={() => <PieSkeleton />}
+        renderLoading={() => <DataLoading />}
         renderError={() => <ChartError chartName="Use of Force" />}
       />
     </>

--- a/frontend/src/Components/Charts/ChartSections/ChartPageBase.styled.js
+++ b/frontend/src/Components/Charts/ChartSections/ChartPageBase.styled.js
@@ -5,6 +5,7 @@ import { phoneOnly, smallerThanDesktop } from 'styles/breakpoints';
 export const ChartPageBase = styled(motion.article)`
   flex: 1;
   overflow-y: scroll;
+  align-self: flex-start;
 `;
 
 export const ChartPageContent = styled.div`

--- a/frontend/src/Components/Elements/Skeletons/BarSkeleton.js
+++ b/frontend/src/Components/Elements/Skeletons/BarSkeleton.js
@@ -4,7 +4,7 @@ import React from 'react';
 import ContentLoader from 'react-content-loader';
 import LoaderBase from 'Components/Elements/Skeletons/LoaderBase';
 
-function PieSkeleton() {
+function BarSkeleton() {
   return (
     <LoaderBase>
       <ContentLoader
@@ -24,4 +24,4 @@ function PieSkeleton() {
   );
 }
 
-export default PieSkeleton;
+export default BarSkeleton;

--- a/frontend/src/Components/Elements/Skeletons/PieSkeleton.js
+++ b/frontend/src/Components/Elements/Skeletons/PieSkeleton.js
@@ -4,26 +4,27 @@ import React from 'react';
 import ContentLoader from 'react-content-loader';
 import LoaderBase from 'Components/Elements/Skeletons/LoaderBase';
 
-function PieSkeleton() {
+function PieSkeleton({ scale=1 }) {
+  const toScale = (val) => parseInt(val, 10) * scale
   return (
     <LoaderBase>
       <ContentLoader
-        viewBox="0 0 400 200"
-        height={200}
-        width={400}
+        viewBox={`0 0 ${toScale(400)} ${toScale(200)}`}
+        height={toScale(200)}
+        width={toScale(400)}
         speed={2}
         data-testid="PieSkeleton"
       >
-        <rect x="100" y="5" rx="0" ry="0" width="200" height="15" />
-        <circle cx="140" cy="110" r="70" />
-        <rect x="230" y="50" rx="0" ry="0" width="7" height="7" />
-        <rect x="250" y="50" rx="0" ry="0" width="30" height="7" />
-        <rect x="230" y="64" rx="0" ry="0" width="7" height="7" />
-        <rect x="250" y="64" rx="0" ry="0" width="30" height="7" />
-        <rect x="230" y="78" rx="0" ry="0" width="7" height="7" />
-        <rect x="250" y="78" rx="0" ry="0" width="30" height="7" />
-        <rect x="230" y="92" rx="0" ry="0" width="7" height="7" />
-        <rect x="250" y="92" rx="0" ry="0" width="30" height="7" />
+        <rect x={toScale(100)} y={toScale(5)} rx={toScale(0)} ry={toScale(0)} width={toScale(200)} height={toScale(1)} />
+        <circle cx={toScale(140)} cy={toScale(110)} r={toScale(70)} />
+        <rect x={toScale(230)} y={toScale(50)} rx={toScale(0)} ry={toScale(0)} width={toScale(7)} height={toScale(7)} />
+        <rect x={toScale(250)} y={toScale(50)} rx={toScale(0)} ry={toScale(0)} width={toScale(30)} height={toScale(7)} />
+        <rect x={toScale(230)} y={toScale(64)} rx={toScale(0)} ry={toScale(0)} width={toScale(7)} height={toScale(7)} />
+        <rect x={toScale(250)} y={toScale(64)} rx={toScale(0)} ry={toScale(0)} width={toScale(30)} height={toScale(7)} />
+        <rect x={toScale(230)} y={toScale(78)} rx={toScale(0)} ry={toScale(0)} width={toScale(7)} height={toScale(7)} />
+        <rect x={toScale(250)} y={toScale(78)} rx={toScale(0)} ry={toScale(0)} width={toScale(30)} height={toScale(7)} />
+        <rect x={toScale(230)} y={toScale(92)} rx={toScale(0)} ry={toScale(0)} width={toScale(7)} height={toScale(7)} />
+        <rect x={toScale(250)} y={toScale(92)} rx={toScale(0)} ry={toScale(0)} width={toScale(30)} height={toScale(7)} />
       </ContentLoader>
     </LoaderBase>
   );


### PR DESCRIPTION
Makes the loading skeletons a bit larger and adds "Loading {agency | officer} data..." text to make loading states more obvious. Added it to both the bundle loading and the chart data loading.

You can test this locally or on staging by loading a chart page. If it loads too quickly to see the loading indicators, use dev tools Network tab to throttle your connection (probably "slow 3g" is good).