### PR TITLE
[FJ-137] AgencyDetail scroll issue

### DIFF
--- a/frontend/src/Components/Charts/ChartSections/ChartPageBase.styled.js
+++ b/frontend/src/Components/Charts/ChartSections/ChartPageBase.styled.js
@@ -6,6 +6,7 @@ export const ChartPageBase = styled(motion.article)`
   flex: 1;
   overflow-y: scroll;
   align-self: flex-start;
+  height: 100%;
 `;
 
 export const ChartPageContent = styled.div`


### PR DESCRIPTION
Adds static height to the `<article>` containing the charts section, so that `overflow-y: auto` is respected.