### PR TITLE
[#11498] Add tooltips to charts

### DIFF
--- a/frontend/src/Components/Charts/ChartPrimitives/CopwatchChart.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/CopwatchChart.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import * as S from './CopwatchChart.styled'
+import { VictoryChart, VictoryVoronoiContainer, VictoryTooltip } from 'victory'
+
+function CopwatchChart({ children, yAxisLabel, transformCenter, voronoiDimension = "x", ...props }) {
+  return (
+    <VictoryChart
+      {...props}
+      containerComponent={
+        <VictoryVoronoiContainer
+          voronoiDimension={voronoiDimension}
+          style={{ touchAction: 'auto' }}
+          labels={() => ' '}
+          labelComponent={<CopwatchTooltip yAxisLabel={yAxisLabel} transformCenter={transformCenter} />}
+        />}
+    >
+      {children}
+    </VictoryChart>
+  )
+}
+
+export default CopwatchChart;
+
+export function CopwatchTooltip({ yAxisLabel, transformCenter, pie, ...props }) {
+  return (
+    <VictoryTooltip
+      {...props}
+      renderInPortal={true}
+      flyoutComponent={<CopwatchChartFlyout yAxisLabel={yAxisLabel} pie={pie} transformCenter={transformCenter} />}
+    />
+  )
+}
+
+CopwatchTooltip.defaultEvents = VictoryTooltip.defaultEvents;
+
+const VORONOI_LABEL_X_OFFSET = 10;
+const defaultYAxisLabel = (value) => value;
+const defaultTransformCenter = ({ x, y, datum }) => ({ x: x + VORONOI_LABEL_X_OFFSET, y: y - datum.height })
+
+export function CopwatchChartFlyout({ yAxisLabel = defaultYAxisLabel, transformCenter = defaultTransformCenter, pie, ...data }) {
+  const centered = transformCenter({ x: data.center.x, y: data.center.y, datum: data })
+
+  const isVoronoi = !!data.activePoints
+
+  const getColor = (d) => {
+    if (pie) {
+      return d.datum.color
+    }
+    if (isVoronoi) {
+      return d.color || d.style.data.stroke
+    }
+    return d.datum.color
+  }
+
+  const getLabel = d => {
+    if (pie) {
+      return d.datum.x
+    }
+    if (isVoronoi) {
+      return d.displayName
+    }
+    return d.datum.ethnicGroup
+  }
+
+  const getValue = d => {
+    if (pie) {
+      return yAxisLabel(d.datum.y)
+    }
+    if (isVoronoi) {
+      return yAxisLabel(d.y)
+    }
+    return yAxisLabel(d.datum.y)
+  }
+
+  return (
+    <foreignObject width="100%" height="100%" {...centered}>
+      <S.FlyoutContainer
+        xmlns="http://www.w3.org/1999/xhtml"
+        data-testid="graphTooltip"
+      >
+        {!pie && <S.FlyoutLabel>{data.datum.x}</S.FlyoutLabel>}
+        <S.DataList >
+          {
+            data.activePoints?.map(p => <S.DataListItem color={getColor(p)} key={getLabel(p)}><S.DatumLabel>{getLabel(p)}:</S.DatumLabel> <S.DatumValue>{getValue(p)}</S.DatumValue></S.DataListItem>)
+            || <S.DataListItem color={getColor(data)} key={getLabel(data)}><S.DatumLabel>{getLabel(data)}:</S.DatumLabel> <S.DatumValue>{getValue(data)}</S.DatumValue></S.DataListItem>
+          }
+        </S.DataList>
+      </S.FlyoutContainer>
+    </foreignObject>
+  )
+}

--- a/frontend/src/Components/Charts/ChartPrimitives/CopwatchChart.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/CopwatchChart.js
@@ -21,12 +21,12 @@ function CopwatchChart({ children, yAxisLabel, transformCenter, voronoiDimension
 
 export default CopwatchChart;
 
-export function CopwatchTooltip({ yAxisLabel, transformCenter, pie, ...props }) {
+export function CopwatchTooltip({ yAxisLabel, transformCenter, pie, tooltipFontSize = null, ...props }) {
   return (
     <VictoryTooltip
       {...props}
       renderInPortal={true}
-      flyoutComponent={<CopwatchChartFlyout yAxisLabel={yAxisLabel} pie={pie} transformCenter={transformCenter} />}
+      flyoutComponent={<CopwatchChartFlyout tooltipFontSize={tooltipFontSize} yAxisLabel={yAxisLabel} pie={pie} transformCenter={transformCenter} />}
     />
   )
 }
@@ -37,7 +37,7 @@ const VORONOI_LABEL_X_OFFSET = 10;
 const defaultYAxisLabel = (value) => value;
 const defaultTransformCenter = ({ x, y, datum }) => ({ x: x + VORONOI_LABEL_X_OFFSET, y: y - datum.height })
 
-export function CopwatchChartFlyout({ yAxisLabel = defaultYAxisLabel, transformCenter = defaultTransformCenter, pie, ...data }) {
+export function CopwatchChartFlyout({ yAxisLabel = defaultYAxisLabel, transformCenter = defaultTransformCenter, pie, tooltipFontSize, ...data }) {
   const centered = transformCenter({ x: data.center.x, y: data.center.y, datum: data })
 
   const isVoronoi = !!data.activePoints
@@ -72,17 +72,19 @@ export function CopwatchChartFlyout({ yAxisLabel = defaultYAxisLabel, transformC
     return yAxisLabel(d.datum.y)
   }
 
+
   return (
     <foreignObject width="100%" height="100%" {...centered}>
       <S.FlyoutContainer
         xmlns="http://www.w3.org/1999/xhtml"
         data-testid="graphTooltip"
+        fontSize={tooltipFontSize}
       >
         {!pie && <S.FlyoutLabel>{data.datum.x}</S.FlyoutLabel>}
         <S.DataList >
           {
-            data.activePoints?.map(p => <S.DataListItem color={getColor(p)} key={getLabel(p)}><S.DatumLabel>{getLabel(p)}:</S.DatumLabel> <S.DatumValue>{getValue(p)}</S.DatumValue></S.DataListItem>)
-            || <S.DataListItem color={getColor(data)} key={getLabel(data)}><S.DatumLabel>{getLabel(data)}:</S.DatumLabel> <S.DatumValue>{getValue(data)}</S.DatumValue></S.DataListItem>
+            data.activePoints?.map(p => <S.DataListItem color={getColor(p)} fontSize={tooltipFontSize} key={getLabel(p)}><S.DatumLabel>{getLabel(p)}:</S.DatumLabel> <S.DatumValue>{getValue(p)}</S.DatumValue></S.DataListItem>)
+            || <S.DataListItem fontSize={tooltipFontSize} color={getColor(data)} key={getLabel(data)}><S.DatumLabel>{getLabel(data)}:</S.DatumLabel> <S.DatumValue>{getValue(data)}</S.DatumValue></S.DataListItem>
           }
         </S.DataList>
       </S.FlyoutContainer>

--- a/frontend/src/Components/Charts/ChartPrimitives/CopwatchChart.styled.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/CopwatchChart.styled.js
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+import { lighten } from 'styles/styleUtils/lighten-darken'
+
+
+export const FlyoutContainer = styled.div`
+  background: ${props => props.theme.colors.black};
+  color: ${props => props.theme.colors.white};
+  width: fit-content;
+  padding: 0.5rem;
+  border-radius: ${props => props.theme.radii.standard}px;
+`;
+
+export const FlyoutLabel = styled.h4`
+  font-family: ${props => props.theme.fonts.heading};
+  margin-bottom: 0.5rem;
+`;
+
+export const DataList = styled.ul`
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  font-family: ${props => props.theme.fonts.body};
+  font-size: 12px;
+  font-weight: bold;
+`;
+
+export const DataListItem = styled.li`
+  color: ${props => lighten(props.color, 20)};
+  display: flex;
+  
+  &:not(:last-child) {
+    margin-bottom: 5px;
+  }
+`;
+
+export const DatumLabel = styled.span`
+  flex: 1;
+`;
+
+export const DatumValue = styled.span`
+  margin-left: 20px;
+`;

--- a/frontend/src/Components/Charts/ChartPrimitives/CopwatchChart.styled.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/CopwatchChart.styled.js
@@ -6,13 +6,14 @@ export const FlyoutContainer = styled.div`
   background: ${props => props.theme.colors.black};
   color: ${props => props.theme.colors.white};
   width: fit-content;
-  padding: 0.5rem;
+  ${props => props.fontSize ? `font-size: ${props.fontSize}px;`: ''}
+  padding: 4px;
   border-radius: ${props => props.theme.radii.standard}px;
 `;
 
 export const FlyoutLabel = styled.h4`
   font-family: ${props => props.theme.fonts.heading};
-  margin-bottom: 0.5rem;
+  margin-bottom: 2px;
 `;
 
 export const DataList = styled.ul`
@@ -27,6 +28,7 @@ export const DataList = styled.ul`
 export const DataListItem = styled.li`
   color: ${props => lighten(props.color, 20)};
   display: flex;
+  ${props => props.fontSize ? `font-size: ${props.fontSize}px;`: ''}
   
   &:not(:last-child) {
     margin-bottom: 5px;

--- a/frontend/src/Components/Charts/ChartPrimitives/GroupedBar.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/GroupedBar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { CopwatchTooltip } from '../ChartPrimitives/CopwatchChart';
 import { VictoryChart, VictoryGroup, VictoryBar, VictoryAxis, VictoryContainer } from 'victory';
 import { AXIS_STYLE } from './chartConstants';
 import ChartLoading from 'Components/Charts/ChartPrimitives/ChartLoading';
@@ -15,7 +16,7 @@ function GroupedBar({
   chartProps,
   dAxisProps,
   iAxisProps,
-  barProps,
+  barProps
 }) {
   if (loading) return <ChartLoading skeleton={BarSkeleton} />
 
@@ -43,6 +44,10 @@ function GroupedBar({
             style={{
               data: { fill: bar.color },
             }}
+            labels={() => " "}
+            labelComponent={
+              <CopwatchTooltip transformCenter={({ x, y }) => ({ x, y })} yAxisLabel={barProps?.yAxisLabel} />
+            }
             {...barProps}
           />
         ))}
@@ -60,3 +65,4 @@ GroupedBar.defaultProps = {
 };
 
 export default GroupedBar;
+

--- a/frontend/src/Components/Charts/ChartPrimitives/GroupedBar.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/GroupedBar.js
@@ -16,7 +16,8 @@ function GroupedBar({
   chartProps,
   dAxisProps,
   iAxisProps,
-  barProps
+  barProps,
+  toolTipFontSize
 }) {
   if (loading) return <ChartLoading skeleton={BarSkeleton} />
 
@@ -46,7 +47,7 @@ function GroupedBar({
             }}
             labels={() => " "}
             labelComponent={
-              <CopwatchTooltip transformCenter={({ x, y }) => ({ x, y })} yAxisLabel={barProps?.yAxisLabel} />
+              <CopwatchTooltip transformCenter={({ x, y }) => ({ x, y })} yAxisLabel={barProps?.yAxisLabel} tooltipFontSize={toolTipFontSize} />
             }
             {...barProps}
           />

--- a/frontend/src/Components/Charts/ChartPrimitives/Line.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/Line.js
@@ -4,9 +4,11 @@ import React from 'react';
 import { AXIS_STYLE } from './chartConstants';
 
 // Deps
-import { VictoryChart, VictoryLine, VictoryAxis, VictoryContainer } from 'victory';
+import CopwatchChart from 'Components/Charts/ChartPrimitives/CopwatchChart';
+import { VictoryLine, VictoryAxis } from 'victory';
 import ChartLoading from 'Components/Charts/ChartPrimitives/ChartLoading';
 import BarSkeleton from 'Components/Elements/Skeletons/BarSkeleton';
+
 
 function Line({
   data = [],
@@ -17,17 +19,19 @@ function Line({
   dTickFormat,
   dAxisProps = {},
   iAxisProps = {},
+  yAxisLabel
 }) {
   if (loading) return <ChartLoading skeleton={BarSkeleton} />
 
   return (
-    <VictoryChart containerComponent={<VictoryContainer style={{ touchAction: 'auto' }} />}>
+    <CopwatchChart yAxisLabel={yAxisLabel}>
       <VictoryAxis
         dependentAxis
         style={AXIS_STYLE}
         tickFormat={dTickFormat}
         tickValues={dTickValues}
         {...dAxisProps}
+
       />
       <VictoryAxis
         label="Year"
@@ -45,7 +49,7 @@ function Line({
           }}
         />
       ))}
-    </VictoryChart>
+    </CopwatchChart>
   );
 }
 

--- a/frontend/src/Components/Charts/ChartPrimitives/Pie.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/Pie.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
-import { useTheme } from 'styled-components';
 
 // Elements
 import ChartLoading from 'Components/Charts/ChartPrimitives/ChartLoading'
 import PieSkeleton from 'Components/Elements/Skeletons/PieSkeleton';
-import { VictoryPie, VictoryLabel, VictoryTooltip } from 'victory';
+import { VictoryPie } from 'victory';
 import { P, WEIGHTS } from 'styles/StyledComponents/Typography';
+import { CopwatchTooltip } from './CopwatchChart';
 
 const PIE_STYLES = {
   data: {
@@ -18,7 +18,6 @@ const PIE_STYLES = {
 const LABEL_SKIP_ANGLE = 0.4;
 
 function Pie({ data, loading }) {
-  const theme = useTheme();
 
   const _dataIsZeros = (d) => {
     return d.length === 0 || d.every((dt) => dt.y === 0);
@@ -38,38 +37,12 @@ function Pie({ data, loading }) {
     <VictoryPie
       data={data}
       style={PIE_STYLES}
-      labelComponent={<PieLabel theme={theme} />}
+      labelComponent={<CopwatchTooltip pie yAxisLabel={val => `${val}%`} />}
+      labels={() => " "}
       labelRadius={({ innerRadius }) => innerRadius + 80}
     />
   );
 }
-
-const PieLabel = (props) => {
-  const { datum, style, slice, theme } = props;
-  const { startAngle, endAngle } = slice;
-  const sliceAngle = endAngle - startAngle;
-  return (
-    <g>
-      <VictoryLabel
-        {...props}
-        style={{ fontSize: 20, fontFamily: theme.fonts.heading, fill: datum.fontColor }}
-        text={sliceAngle <= LABEL_SKIP_ANGLE ? '' : `${datum.y}%`}
-        // text={datum.y < 5 ? '' : `${Math.floor(datum.y)}%`}
-      />
-      {/* <VictoryTooltip
-        {...props}
-        style={{ ...style, fill: datum.color }}
-        flyoutStyle={{ stroke: theme.colors.primary, fill: theme.colors.white, strokeWidth: 2 }}
-        text={`${datum.displayName}\n${datum.y}%`}
-        orientation="top"
-        pointerLength={5}
-        height={40}
-      /> */}
-    </g>
-  );
-};
-
-PieLabel.defaultEvents = VictoryTooltip.defaultEvents;
 
 const NoData = styled.div`
   text-align: center;

--- a/frontend/src/Components/Charts/ChartPrimitives/StackedBar.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/StackedBar.js
@@ -1,26 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { VictoryChart, VictoryStack, VictoryBar, VictoryAxis, VictoryContainer } from 'victory';
+import { VictoryStack, VictoryBar, VictoryAxis, VictoryTooltip } from 'victory';
 import { AXIS_STYLE } from './chartConstants';
 
 // Children
 import ChartLoading from 'Components/Charts/ChartPrimitives/ChartLoading';
 import BarSkeleton from 'Components/Elements/Skeletons/BarSkeleton';
+import CopwatchChart from './CopwatchChart';
 
-function StackedBar({ data, loading, tickValues }) {
+function StackedBar({ data, loading, tickValues, yAxisLabel }) {
   if (loading) return <ChartLoading skeleton={BarSkeleton} />
 
   return (
-    <VictoryChart
+    <CopwatchChart
       style={{ padding: 0 }}
-      containerComponent={<VictoryContainer style={{ touchAction: 'auto' }} />}
+      yAxisLabel={yAxisLabel}
     >
       <VictoryAxis
         dependentAxis
         style={AXIS_STYLE}
         tickValues={[10, 20, 30, 40, 50, 60, 70, 80, 90, 100]}
         tickFormat={(t) => (t % 20 === 0 ? `${t}%` : null)}
+        labels={({ datum }) => `HEY: ${datum.y} ${datum.x}`}
+        labelComponent={<VictoryTooltip />}
       />
       <VictoryAxis
         label="Year"
@@ -28,7 +31,7 @@ function StackedBar({ data, loading, tickValues }) {
         style={AXIS_STYLE}
         tickFormat={(t) => (t % 2 === 0 ? t : null)}
       />
-      <VictoryStack>
+      <VictoryStack >
         {data.map((bar) => (
           <VictoryBar
             key={bar.id}
@@ -37,10 +40,11 @@ function StackedBar({ data, loading, tickValues }) {
             style={{
               data: { fill: bar.color, opacity: 0.5 },
             }}
+
           />
         ))}
       </VictoryStack>
-    </VictoryChart>
+    </CopwatchChart>
   );
 }
 

--- a/frontend/src/Components/Charts/SearchRate/SearchRate.js
+++ b/frontend/src/Components/Charts/SearchRate/SearchRate.js
@@ -30,7 +30,8 @@ import ChartHeader from 'Components/Charts/ChartSections/ChartHeader';
 import Legend from 'Components/Charts/ChartSections/Legend/Legend';
 import DataSubsetPicker from 'Components/Charts/ChartSections/DataSubsetPicker/DataSubsetPicker';
 import GroupedBar from '../ChartPrimitives/GroupedBar';
-import { VictoryLabel, VictoryTooltip } from 'victory';
+import { VictoryLabel } from 'victory';
+
 
 function SearchRate() {
   let { agencyId } = useParams();
@@ -96,7 +97,8 @@ function SearchRate() {
             data: STOP_TYPES.map((reason) => ({
               x: reason,
               y: ratesByReason[reason],
-              label: `${ratesByReason[reason]}%`,
+              ethnicGroup: g.label,
+              color: theme.colors.ethnicGroup[ethnicGroup],
             })),
           };
         });
@@ -183,13 +185,7 @@ function SearchRate() {
                   height: 500,
                   width: 400,
                 }}
-                barProps={{
-                  barWidth: 10,
-                  labelComponent: (
-                    <VictoryTooltip style={toolTipStyles(theme)} flyoutStyle={barFlyoutStyle} />
-                  ),
-                  events: barEvents,
-                }}
+                barProps={{ barWidth: 10, yAxisLabel: (val) => `${val}%` }}
               />
             )}
           </S.LineWrapper>
@@ -216,51 +212,6 @@ function SearchRate() {
 }
 
 export default SearchRate;
-
-const barEvents = [
-  {
-    target: 'data',
-    eventHandlers: {
-      onMouseOver: () => {
-        return [
-          {
-            target: 'data',
-            mutation: ({ style }) => {
-              const fill = style.fill.slice(0, -2);
-              return { style: { fill } };
-            },
-          },
-          {
-            target: 'labels',
-            mutation: () => ({ active: true }),
-          },
-        ];
-      },
-      onMouseOut: () => {
-        return [
-          {
-            target: 'data',
-            mutation: () => {},
-          },
-          {
-            target: 'labels',
-            mutation: () => ({ active: false }),
-          },
-        ];
-      },
-    },
-  },
-];
-
-const toolTipStyles = (theme) => ({
-  fontFamily: theme.fonts.body,
-  fontSize: 8,
-});
-
-const barFlyoutStyle = {
-  stroke: 'none',
-  fill: 'none',
-};
 
 const TABLE_COLUMNS = [
   {

--- a/frontend/src/Components/Charts/SearchRate/SearchRate.js
+++ b/frontend/src/Components/Charts/SearchRate/SearchRate.js
@@ -186,6 +186,7 @@ function SearchRate() {
                   width: 400,
                 }}
                 barProps={{ barWidth: 10, yAxisLabel: (val) => `${val}%` }}
+                toolTipFontSize={8}
               />
             )}
           </S.LineWrapper>

--- a/frontend/src/Components/Charts/Searches/Searches.js
+++ b/frontend/src/Components/Charts/Searches/Searches.js
@@ -178,6 +178,7 @@ function Searches() {
               dAxisProps={{
                 tickFormat: (t) => `${t}%`,
               }}
+              yAxisLabel={(val) => `${val}%`}
             />
           </S.LineWrapper>
           <S.LegendBeside>

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -226,6 +226,7 @@ function TrafficStops() {
                 data={byPercentageLineData}
                 tickValues={chartState.yearSet}
                 loading={chartState.loading[STOPS]}
+                yAxisLabel={val => `${val}%`}
               />
             </S.LineWrapper>
             <S.LegendBelow>

--- a/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
+++ b/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
@@ -137,6 +137,7 @@ function UseOfForce() {
                 iTickFormat={(t) => (t % 2 === 0 ? t : null)}
                 iTickValues={chartState.yearSet}
                 loading={chartState.loading[USE_OF_FORCE]}
+                toolTipFontSize={16}
               />
             </S.LineWrapper>
             <S.LegendBelow>

--- a/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
+++ b/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
@@ -65,6 +65,8 @@ function UseOfForce() {
             data: data.map((d) => ({
               x: d.year,
               y: d[ethnicGroup],
+              ethnicGroup: eg.label,
+              color: theme.colors.ethnicGroup[ethnicGroup],
             })),
           };
         });

--- a/frontend/src/Components/Charts/chartUtils.js
+++ b/frontend/src/Components/Charts/chartUtils.js
@@ -109,7 +109,8 @@ export function buildStackedBarData(data, filteredKeys, theme) {
       return {
         x: datum.year,
         y: calculatePercentage(datum[ethnicGroup], yearTotals[datum.year]),
-        ethnicGroup: toTitleCase(ethnicGroup),
+        displayName: toTitleCase(ethnicGroup),
+        color: theme.colors.ethnicGroup[ethnicGroup]
       };
     });
     mappedData.push(groupSet);


### PR DESCRIPTION
All charts (except maybe one that was deemed redundant) now have a "tooltip" when you hover over data points.  In some cases it's 1:1-- the data point you hover over is expanded into a tooltip. In other cases, a voronoi is used to calculate the closest intersection of corresponding data points on the dependent axis and all data points are displayed in the tooltip for that point on the x-axis. It makes more sense when you just look at it.

There were a few changes that seemed to have effective performance a bit, so it makes some sense to put these changes to a bit of a stress test both locally and on staging.