### PR TITLE
Resolve: 14244 Make hover display less intrusive

### DIFF
--- a/frontend/src/Components/Charts/ChartPrimitives/CopwatchChart.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/CopwatchChart.js
@@ -2,17 +2,11 @@ import React from 'react';
 import * as S from './CopwatchChart.styled'
 import { VictoryChart, VictoryVoronoiContainer, VictoryTooltip } from 'victory'
 
-function CopwatchChart({ children, yAxisLabel, transformCenter, voronoiDimension = "x", ...props }) {
+function CopwatchChart({ children, ...props }) {
   return (
     <VictoryChart
       {...props}
-      containerComponent={
-        <VictoryVoronoiContainer
-          voronoiDimension={voronoiDimension}
-          style={{ touchAction: 'auto' }}
-          labels={() => ' '}
-          labelComponent={<CopwatchTooltip yAxisLabel={yAxisLabel} transformCenter={transformCenter} />}
-        />}
+      containerComponent={ <VictoryVoronoiContainer />}
     >
       {children}
     </VictoryChart>
@@ -81,12 +75,17 @@ export function CopwatchChartFlyout({ yAxisLabel = defaultYAxisLabel, transformC
         fontSize={tooltipFontSize}
       >
         {!pie && <S.FlyoutLabel>{data.datum.x}</S.FlyoutLabel>}
-        <S.DataList >
+        <S.DataList>
           {
-            data.activePoints?.map(p => <S.DataListItem color={getColor(p)} fontSize={tooltipFontSize} key={getLabel(p)}><S.DatumLabel>{getLabel(p)}:</S.DatumLabel> <S.DatumValue>{getValue(p)}</S.DatumValue></S.DataListItem>)
-            || <S.DataListItem fontSize={tooltipFontSize} color={getColor(data)} key={getLabel(data)}><S.DatumLabel>{getLabel(data)}:</S.DatumLabel> <S.DatumValue>{getValue(data)}</S.DatumValue></S.DataListItem>
+            data.activePoints?.map(p => <S.DataListItem color={getColor(p)} fontSize={tooltipFontSize}
+                                                        key={getLabel(p)}><S.DatumLabel>{getLabel(p)}:</S.DatumLabel>
+              <S.DatumValue>{getValue(p)}</S.DatumValue></S.DataListItem>)
+            || <S.DataListItem fontSize={tooltipFontSize} color={getColor(data)}
+                               key={getLabel(data)}><S.DatumLabel>{getLabel(data)}:</S.DatumLabel>
+              <S.DatumValue>{getValue(data)}</S.DatumValue></S.DataListItem>
           }
         </S.DataList>
+
       </S.FlyoutContainer>
     </foreignObject>
   )

--- a/frontend/src/Components/Charts/ChartPrimitives/CopwatchChart.styled.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/CopwatchChart.styled.js
@@ -1,14 +1,16 @@
 import styled from 'styled-components';
-import { lighten } from 'styles/styleUtils/lighten-darken'
+import {darken, lighten} from 'styles/styleUtils/lighten-darken'
 
 
 export const FlyoutContainer = styled.div`
-  background: ${props => props.theme.colors.black};
-  color: ${props => props.theme.colors.white};
+  background: ${props => props.theme.colors.white};
+  color: ${props => props.theme.colors.black};
   width: fit-content;
   ${props => props.fontSize ? `font-size: ${props.fontSize}px;`: ''}
   padding: 4px;
   border-radius: ${props => props.theme.radii.standard}px;
+  border-style: solid;
+  border-width: thin;
 `;
 
 export const FlyoutLabel = styled.h4`
@@ -26,7 +28,7 @@ export const DataList = styled.ul`
 `;
 
 export const DataListItem = styled.li`
-  color: ${props => lighten(props.color, 20)};
+  color: ${props => darken(props.color, 10)};
   display: flex;
   ${props => props.fontSize ? `font-size: ${props.fontSize}px;`: ''}
   

--- a/frontend/src/Components/Charts/ChartPrimitives/GroupedBar.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/GroupedBar.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { CopwatchTooltip } from '../ChartPrimitives/CopwatchChart';
-import { VictoryChart, VictoryGroup, VictoryBar, VictoryAxis, VictoryContainer } from 'victory';
+import {VictoryChart, VictoryGroup, VictoryBar, VictoryAxis, VictoryContainer, VictoryTooltip} from 'victory';
 import { AXIS_STYLE } from './chartConstants';
 import ChartLoading from 'Components/Charts/ChartPrimitives/ChartLoading';
 import BarSkeleton from 'Components/Elements/Skeletons/BarSkeleton';
@@ -45,10 +45,8 @@ function GroupedBar({
             style={{
               data: { fill: bar.color },
             }}
-            labels={() => " "}
-            labelComponent={
-              <CopwatchTooltip transformCenter={({ x, y }) => ({ x, y })} yAxisLabel={barProps?.yAxisLabel} tooltipFontSize={toolTipFontSize} />
-            }
+            labels={({ datum }) => `${datum.ethnicGroup}, ${datum.x}, ${dAxisProps.tickFormat(datum.y)}`}
+            labelComponent={<VictoryTooltip style={{ fontSize: toolTipFontSize }}/>}
             {...barProps}
           />
         ))}

--- a/frontend/src/Components/Charts/ChartPrimitives/Line.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/Line.js
@@ -4,8 +4,8 @@ import React from 'react';
 import { AXIS_STYLE } from './chartConstants';
 
 // Deps
-import CopwatchChart from 'Components/Charts/ChartPrimitives/CopwatchChart';
-import { VictoryLine, VictoryAxis } from 'victory';
+import CopwatchChart, {CopwatchTooltip} from 'Components/Charts/ChartPrimitives/CopwatchChart';
+import {VictoryLine, VictoryAxis, VictoryTooltip} from 'victory';
 import ChartLoading from 'Components/Charts/ChartPrimitives/ChartLoading';
 import BarSkeleton from 'Components/Elements/Skeletons/BarSkeleton';
 
@@ -47,6 +47,8 @@ function Line({
           style={{
             data: { stroke: lineData.color },
           }}
+          labels={({ datum }) => `${datum.x}, ${datum.displayName}, ${dAxisProps.tickFormat(datum.y)}`}
+          labelComponent={<VictoryTooltip style={{ fontSize: 10 }}/>}
         />
       ))}
     </CopwatchChart>

--- a/frontend/src/Components/Charts/ChartPrimitives/StackedBar.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/StackedBar.js
@@ -40,7 +40,8 @@ function StackedBar({ data, loading, tickValues, yAxisLabel }) {
             style={{
               data: { fill: bar.color, opacity: 0.5 },
             }}
-
+            labels={({ datum }) => `${datum.x}, ${datum.displayName}, ${datum.y}%`}
+            labelComponent={<VictoryTooltip style={{ fontSize: 10 }}/>}
           />
         ))}
       </VictoryStack>

--- a/frontend/src/Components/Charts/Searches/Searches.js
+++ b/frontend/src/Components/Charts/Searches/Searches.js
@@ -210,6 +210,9 @@ function Searches() {
               iAxisProps={{
                 minDomain: { y: 1 },
               }}
+              dAxisProps={{
+                tickFormat: (t) => `${t}`,
+              }}
             />
           </S.LineWrapper>
           <S.LegendBeside>

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -263,6 +263,9 @@ function TrafficStops() {
               loading={chartState.loading[STOPS_BY_REASON]}
               iTickFormat={(t) => (t % 2 === 0 ? t : null)}
               iTickValues={chartState.yearSet}
+              dAxisProps={{
+                tickFormat: (t) => `${t}`,
+              }}
             />
           </S.LineWrapper>
           <S.LegendBeside>

--- a/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
+++ b/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
@@ -138,6 +138,9 @@ function UseOfForce() {
                 iTickValues={chartState.yearSet}
                 loading={chartState.loading[USE_OF_FORCE]}
                 toolTipFontSize={16}
+                dAxisProps={{
+                  tickFormat: (t) => `${t}`,
+                }}
               />
             </S.LineWrapper>
             <S.LegendBelow>


### PR DESCRIPTION
Update charts to use `VelocityTooltip` in favor of CopwatchChart tooltip. Since it's supported out of the box. 

Preview:
![Screen Shot 2022-04-29 at 4 43 58 PM](https://user-images.githubusercontent.com/26633909/166067302-18f45d8a-4978-4b56-aa6e-1af1b3e72cb4.png)

Issue
[Story 14244](https://app.shortcut.com/caktusgroup/story/14244/make-hover-display-less-intrusive)