### PR TITLE
Resolve: 14246  Include a "Total" likelihood of search to the search rate graph display

### DIFF
--- a/frontend/src/Components/Charts/SearchRate/SearchRate.js
+++ b/frontend/src/Components/Charts/SearchRate/SearchRate.js
@@ -20,7 +20,7 @@ import {
   YEARS_DEFAULT,
   getGroupValueBasedOnYear,
   getRatesAgainstBase,
-  STOP_TYPES,
+  STOP_TYPES, calculateAveragePercentage,
 } from '../chartUtils';
 import { AGENCY_LIST_SLUG, SEARCHES_SLUG } from 'Routes/slugs';
 
@@ -69,7 +69,7 @@ function SearchRate() {
         setNoBaseSearches(false);
       }
       const baseGroupTotalStops = getGroupValueBasedOnYear(data.stops, 'white', year, STOP_TYPES);
-      const mappedData = ethnicGroupKeys
+      let mappedData = ethnicGroupKeys
         .filter((g) => g.selected && g.value !== 'white')
         .map((g) => {
           const ethnicGroup = g.value;
@@ -102,6 +102,7 @@ function SearchRate() {
             })),
           };
         });
+      mappedData = calculateAveragePercentage(mappedData);
       setChartData(mappedData);
     }
   }, [chartState.data[LIKELIHOOD_OF_SEARCH], ethnicGroupKeys, year]);

--- a/frontend/src/Components/Charts/chartUtils.js
+++ b/frontend/src/Components/Charts/chartUtils.js
@@ -19,6 +19,7 @@ export const STOP_TYPES = [
   'Investigation',
   'Other Motor Vehicle Violation',
   'Checkpoint',
+  'Average'
 ];
 export const YEARS_DEFAULT = 'All';
 export const PURPOSE_DEFAULT = 'All';
@@ -205,3 +206,12 @@ export const getRatesAgainstBase = (baseSearches, baseStops, groupSearches, grou
   }
   return rData;
 };
+
+export const calculateAveragePercentage = (data) => {
+  data.forEach(da => {
+    let dataPoints = da.data.filter(d => d.x !== "Average").map(p => p.y);
+    let averageDataPoint = da.data.filter(d => d.x === "Average")[0];
+    averageDataPoint["y"] = (dataPoints.reduce((a, b) => a + b, 0)) / dataPoints.length;
+  })
+  return data;
+}


### PR DESCRIPTION
- Add an "Average" data point for Likelihood of Search graph

Preview:
![Screen Shot 2022-05-02 at 11 41 05 AM](https://user-images.githubusercontent.com/26633909/166263936-5a36e56d-1023-4a44-8bfb-c02e69bab5c7.png)

Note: The hover graphs have been updated in another PR. 

Closes #14246
