### PR TITLE
Resolve: 12496 Missing 'Officer' text

### DIFF
--- a/frontend/src/Components/AgencyData/AgencyHeader.js
+++ b/frontend/src/Components/AgencyData/AgencyHeader.js
@@ -28,6 +28,14 @@ function AgencyHeader({ agencyHeaderOpen, agencyDetails }) {
     history.push(`${AGENCY_LIST_SLUG}/${agencyId}`);
   };
 
+  let lastReportedStop = () => {
+    if (officerId) {
+      return `last reported stop from officer`;
+    } else if (agencyId) {
+      return `last reported stop from department`;
+    }
+  }
+
   return (
     <AnimatePresence>
       {agencyHeaderOpen && (
@@ -64,7 +72,7 @@ function AgencyHeader({ agencyHeaderOpen, agencyDetails }) {
                   <S.AgencyTitle>{agencyDetails.name}</S.AgencyTitle>
                 )}
                 <P size={SIZES[0]} color={COLORS[0]} weight={WEIGHTS[0]}>
-                  last reported stop {agencyId ? 'from department ' : ''}
+                  {lastReportedStop()}
                   {agencyDetails.last_reported_stop && 'on'}
                   <S.ReportedDate size={SIZES[0]} color={COLORS[0]} weight={WEIGHTS[1]}>
                     {' '}

--- a/frontend/src/Components/Charts/Overview/Overview.js
+++ b/frontend/src/Components/Charts/Overview/Overview.js
@@ -27,12 +27,14 @@ import useDataset, { AGENCY_DETAILS, STOPS, SEARCHES, USE_OF_FORCE } from 'Hooks
 import ChartHeader from 'Components/Charts/ChartSections/ChartHeader';
 import Pie from 'Components/Charts/ChartPrimitives/Pie';
 import Legend from 'Components/Charts/ChartSections/Legend/Legend';
+import useOfficerId from "../../../Hooks/useOfficerId";
 
 function Overview() {
   const { agencyId } = useParams();
   const theme = useTheme();
   const history = useHistory();
   const match = useRouteMatch();
+  const officerId = useOfficerId();
 
   useDataset(agencyId, STOPS);
   useDataset(agencyId, SEARCHES);
@@ -46,6 +48,14 @@ function Overview() {
   const [useOfForceData, setUseOfForceData] = useState([]);
 
   const renderMetaTags = useMetaTags();
+
+  const subjectObserving = () => {
+    if (officerId) {
+      return "officer";
+    } else if (agencyId) {
+      return "department";
+    }
+  }
 
   /* Build Data */
   // CENSUS
@@ -138,7 +148,7 @@ function Overview() {
             <Pie loading={chartState.loading[STOPS]} data={trafficStopsData} />
             <Legend keys={STATIC_LEGEND_KEYS} isStatic showNonHispanic />
           </S.PieWrapper>
-          <S.Note>Shows the race/ethnic composition of drivers stopped by this department</S.Note>
+          <S.Note>Shows the race/ethnic composition of drivers stopped by this {subjectObserving()}</S.Note>
           <S.Link onClick={() => history.push(`${match.url}${slugs.TRAFFIC_STOPS_SLUG}`)}>
             View traffic stops over time
           </S.Link>
@@ -151,7 +161,7 @@ function Overview() {
             <Pie loading={chartState.loading[SEARCHES]} data={searchesData} />
             <Legend keys={STATIC_LEGEND_KEYS} isStatic showNonHispanic />
           </S.PieWrapper>
-          <S.Note>Shows the race/ethnic composition of drivers searched by this department</S.Note>
+          <S.Note>Shows the race/ethnic composition of drivers searched by this {subjectObserving()}</S.Note>
           <S.Link onClick={() => history.push(`${match.url}${slugs.SEARCHES_SLUG}`)}>
             View searches over time
           </S.Link>

--- a/frontend/src/Components/Charts/Searches/Searches.js
+++ b/frontend/src/Components/Charts/Searches/Searches.js
@@ -33,10 +33,13 @@ import Line from 'Components/Charts/ChartPrimitives/Line';
 import Legend from 'Components/Charts/ChartSections/Legend/Legend';
 import ChartHeader from 'Components/Charts/ChartSections/ChartHeader';
 import DataSubsetPicker from 'Components/Charts/ChartSections/DataSubsetPicker/DataSubsetPicker';
+import useOfficerId from "../../../Hooks/useOfficerId";
 
 function Searches() {
   let { agencyId } = useParams();
   const theme = useTheme();
+
+  const officerId = useOfficerId();
 
   useDataset(agencyId, STOPS);
   useDataset(agencyId, SEARCHES);
@@ -155,9 +158,17 @@ function Searches() {
     openModal(SEARCHES_BY_TYPE, COUNT_COLUMNS);
   };
 
+  const subjectObserving = () => {
+    if (officerId) {
+      return "officer";
+    } else if (agencyId) {
+      return "department";
+    }
+  }
+
   return (
     <SearchesStyled>
-      {/* Searche Rate */}
+      {/* Search Rate */}
       {renderMetaTags()}
       {renderTableModal()}
       <S.ChartSection>
@@ -197,7 +208,7 @@ function Searches() {
       <S.ChartSection>
         <ChartHeader chartTitle="Searches By Count" handleViewData={handleViewCountData} />
         <P>
-          Shows the number of searches performed by the department, broken down by search type and
+          Shows the number of searches performed by the {subjectObserving()}, broken down by search type and
           race / ethnicity.
         </P>
         <S.ChartSubsection>

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -38,10 +38,12 @@ import Legend from 'Components/Charts/ChartSections/Legend/Legend';
 import ChartHeader from 'Components/Charts/ChartSections/ChartHeader';
 import DataSubsetPicker from 'Components/Charts/ChartSections/DataSubsetPicker/DataSubsetPicker';
 import toTitleCase from 'util/toTitleCase';
+import useOfficerId from "../../../Hooks/useOfficerId";
 
 function TrafficStops() {
   let { agencyId } = useParams();
   const theme = useTheme();
+  const officerId = useOfficerId();
 
   useDataset(agencyId, STOPS_BY_REASON);
   const [chartState] = useDataset(agencyId, STOPS);
@@ -204,6 +206,14 @@ function TrafficStops() {
     }
   };
 
+  const subjectObserving = () => {
+    if (officerId) {
+      return "officer";
+    } else if (agencyId) {
+      return "department";
+    }
+  }
+
   return (
     <TrafficStopsStyled>
       {/* Traffic Stops by Percentage */}
@@ -215,7 +225,7 @@ function TrafficStops() {
           handleViewData={handleViewPercentageData}
         />
         <S.ChartDescription>
-          <P>Shows the race/ethnic composition of drivers stopped by this department over time.</P>
+          <P>Shows the race/ethnic composition of drivers stopped by this {subjectObserving()} over time.</P>
           <P>{getChartDetailedBreakdown()}</P>
         </S.ChartDescription>
         <S.ChartSubsection>


### PR DESCRIPTION
Update spots where "department" is used for an officer page. 

Example: "stop from officer" was previously "stop from department"
![Screen Shot 2022-05-12 at 2 09 07 PM](https://user-images.githubusercontent.com/26633909/168143052-6d7d481b-b198-40d9-9d52-489d6f483d46.png)


Closes #12496
