### PR TITLE
Resolve: 14044 Graph performance issues

### DIFF
--- a/frontend/src/Components/Charts/ChartPrimitives/StackedBar.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/StackedBar.js
@@ -1,19 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { VictoryStack, VictoryBar, VictoryAxis, VictoryTooltip } from 'victory';
+import {VictoryStack, VictoryBar, VictoryAxis, VictoryTooltip, VictoryChart} from 'victory';
 import { AXIS_STYLE } from './chartConstants';
 
 // Children
 import ChartLoading from 'Components/Charts/ChartPrimitives/ChartLoading';
 import BarSkeleton from 'Components/Elements/Skeletons/BarSkeleton';
-import CopwatchChart from './CopwatchChart';
 
 function StackedBar({ data, loading, tickValues, yAxisLabel }) {
   if (loading) return <ChartLoading skeleton={BarSkeleton} />
 
   return (
-    <CopwatchChart
+    <VictoryChart
       style={{ padding: 0 }}
       yAxisLabel={yAxisLabel}
     >
@@ -31,7 +30,7 @@ function StackedBar({ data, loading, tickValues, yAxisLabel }) {
         style={AXIS_STYLE}
         tickFormat={(t) => (t % 2 === 0 ? t : null)}
       />
-      <VictoryStack >
+      <VictoryStack>
         {data.map((bar) => (
           <VictoryBar
             key={bar.id}
@@ -40,12 +39,12 @@ function StackedBar({ data, loading, tickValues, yAxisLabel }) {
             style={{
               data: { fill: bar.color, opacity: 0.5 },
             }}
-            labels={({ datum }) => `${datum.x}, ${datum.displayName}, ${datum.y}%`}
+            labels={({ datum }) => datum ? `${datum.x}, ${datum.displayName}, ${datum.y}%` : ""}
             labelComponent={<VictoryTooltip style={{ fontSize: 10 }}/>}
           />
         ))}
       </VictoryStack>
-    </CopwatchChart>
+    </VictoryChart>
   );
 }
 

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -43,8 +43,8 @@ function TrafficStops() {
   let { agencyId } = useParams();
   const theme = useTheme();
 
-  useDataset(agencyId, STOPS_BY_REASON);
-  const [chartState] = useDataset(agencyId, STOPS);
+  const [stopsChartState] = useDataset(agencyId, STOPS);
+  const [reasonChartState] = useDataset(agencyId, STOPS_BY_REASON);
 
   const [year, setYear] = useState(YEARS_DEFAULT);
 
@@ -81,17 +81,17 @@ function TrafficStops() {
   /* CALCULATE AND BUILD CHART DATA */
   // Build data for Stops by Percentage line chart
   useEffect(() => {
-    const data = chartState.data[STOPS];
+    const data = stopsChartState.data[STOPS];
     if (data) {
       const filteredGroups = percentageEthnicGroups.filter((g) => g.selected).map((g) => g.value);
       const derivedData = buildStackedBarData(data, filteredGroups, theme);
       setByPercentageLineData(derivedData);
     }
-  }, [chartState.data[STOPS], percentageEthnicGroups]);
+  }, [stopsChartState.data[STOPS], percentageEthnicGroups]);
 
   // Build data for Stops by Percentage pie chart
   useEffect(() => {
-    const data = chartState.data[STOPS];
+    const data = stopsChartState.data[STOPS];
     if (data) {
       if (!year || year === 'All') {
         setByPercentagePieData(reduceFullDataset(data, RACES, theme));
@@ -108,11 +108,11 @@ function TrafficStops() {
         );
       }
     }
-  }, [chartState.data[STOPS], year]);
+  }, [stopsChartState.data[STOPS], year]);
 
   // Build data for Stops By Count line chart ("All")
   useEffect(() => {
-    const data = chartState.data[STOPS];
+    const data = stopsChartState.data[STOPS];
     if (data && purpose === PURPOSE_DEFAULT) {
       const derivedData = countEthnicGroups
         .filter((g) => g.selected)
@@ -131,11 +131,11 @@ function TrafficStops() {
         });
       setByCountLineData(derivedData);
     }
-  }, [chartState.data[STOPS], purpose, countEthnicGroups]);
+  }, [stopsChartState.data[STOPS], purpose, countEthnicGroups]);
 
   // Build data for Stops By Count line chart (single purpose)
   useEffect(() => {
-    const data = chartState.data[STOPS_BY_REASON]?.stops;
+    const data = reasonChartState.data[STOPS_BY_REASON]?.stops;
     if (data && purpose !== PURPOSE_DEFAULT) {
       const purposeData = filterSinglePurpose(data, purpose);
       const derivedData = countEthnicGroups
@@ -154,7 +154,7 @@ function TrafficStops() {
         });
       setByCountLineData(derivedData);
     }
-  }, [chartState.data[STOPS_BY_REASON], purpose, countEthnicGroups]);
+  }, [reasonChartState.data[STOPS_BY_REASON], purpose, countEthnicGroups]);
 
   /* INTERACTIONS */
   // Handle year dropdown state
@@ -224,8 +224,8 @@ function TrafficStops() {
               <StackedBar
                 horizontal
                 data={byPercentageLineData}
-                tickValues={chartState.yearSet}
-                loading={chartState.loading[STOPS]}
+                tickValues={stopsChartState.yearSet}
+                loading={stopsChartState.loading[STOPS]}
                 yAxisLabel={val => `${val}%`}
               />
             </S.LineWrapper>
@@ -241,13 +241,13 @@ function TrafficStops() {
           </S.LineSection>
           <S.PieSection>
             <S.PieWrapper>
-              <Pie data={byPercentagePieData} loading={chartState.loading[STOPS]} />
+              <Pie data={byPercentagePieData} loading={stopsChartState.loading[STOPS]} />
             </S.PieWrapper>
             <DataSubsetPicker
               label="Year"
               value={year}
               onChange={handleYearSelect}
-              options={[YEARS_DEFAULT].concat(chartState.yearRange)}
+              options={[YEARS_DEFAULT].concat(stopsChartState.yearRange)}
             />
           </S.PieSection>
         </S.ChartSubsection>
@@ -260,9 +260,9 @@ function TrafficStops() {
           <S.LineWrapper>
             <Line
               data={byCountLineData}
-              loading={chartState.loading[STOPS_BY_REASON]}
+              loading={reasonChartState.loading[STOPS_BY_REASON]}
               iTickFormat={(t) => (t % 2 === 0 ? t : null)}
-              iTickValues={chartState.yearSet}
+              iTickValues={reasonChartState.yearSet}
               dAxisProps={{
                 tickFormat: (t) => `${t}`,
               }}


### PR DESCRIPTION
Wrapping the `StackedBar` in a component using `VictoryVoronoiContainer` caused the site to crash when you remove an ethnicity from the "TRAFFIC STOPS BY PERCENTAGE" chart. 

The `VictoryVoronoiContainer` is needed to display labels for line charts.

Also cleaned up a bit of logic, there were lingering api calls that caused me some confusion to its purpose. 