### PR TITLE
Resolve: 14909 Change plural officers subtext on Use Of Force page to indicate the singular officer it shows data for

### DIFF
--- a/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
+++ b/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
@@ -31,9 +31,11 @@ import DataSubsetPicker from 'Components/Charts/ChartSections/DataSubsetPicker/D
 import GroupedBar from 'Components/Charts/ChartPrimitives/GroupedBar';
 import Pie from 'Components/Charts/ChartPrimitives/Pie';
 import toTitleCase from 'util/toTitleCase';
+import useOfficerId from "../../../Hooks/useOfficerId";
 
 function UseOfForce() {
   let { agencyId } = useParams();
+  const officerId = useOfficerId();
   const theme = useTheme();
 
   const [chartState] = useDataset(agencyId, USE_OF_FORCE);
@@ -49,6 +51,14 @@ function UseOfForce() {
 
   const renderMetaTags = useMetaTags();
   const [renderTableModal, { openModal }] = useTableModal();
+
+  const subjectObserving = () => {
+    if (officerId) {
+      return "whom this officer";
+    } else if (agencyId) {
+      return "whom law enforcement officers";
+    }
+  }
 
   /* BUILD DATA */
   // Bar chart data
@@ -125,7 +135,7 @@ function UseOfForce() {
         <ChartHeader chartTitle="Use of Force" handleViewData={handleViewData} />
         <S.ChartDescription>
           <P>
-            Shows the race/ethnic composition of drivers whom law enforcement officers reported
+            Shows the race/ethnic composition of drivers {subjectObserving()} reported
             using force against
           </P>
         </S.ChartDescription>


### PR DESCRIPTION
- Update wording for officer pages in use of force chart

Preview:
![Screen Shot 2022-06-16 at 2 21 47 PM](https://user-images.githubusercontent.com/26633909/174139827-82c394e2-5e95-4249-a5d9-7da954b9478a.png)
![Screen Shot 2022-06-16 at 2 21 38 PM](https://user-images.githubusercontent.com/26633909/174139829-a2dd6372-2c4b-4d90-a98b-6e32312b64ed.png)

Closes #14909
