### PR TITLE
Resolve: 15707 Fix tooltip cropped in search rate graph

### DIFF
--- a/frontend/src/Components/Charts/ChartPrimitives/GroupedBar.js
+++ b/frontend/src/Components/Charts/ChartPrimitives/GroupedBar.js
@@ -49,7 +49,13 @@ function GroupedBar({
               data: { fill: bar.color },
             }}
             labels={({ datum }) => `${datum.ethnicGroup}, ${datum.x}, ${dAxisProps.tickFormat(datum.y)}`}
-            labelComponent={<VictoryTooltip style={{ fontSize: toolTipFontSize }}/>}
+            labelComponent={
+              <VictoryTooltip
+                  constrainToVisibleArea
+                  flyoutStyle={{ opacity: 0.8 }}
+                  style={{ fontSize: toolTipFontSize }}
+              />
+            }
             {...barProps}
           />
         ))}

--- a/frontend/src/Components/Charts/SearchRate/SearchRate.js
+++ b/frontend/src/Components/Charts/SearchRate/SearchRate.js
@@ -187,7 +187,7 @@ function SearchRate() {
                   width: 400,
                 }}
                 barProps={{ barWidth: 10, yAxisLabel: (val) => `${val}%` }}
-                toolTipFontSize={8}
+                toolTipFontSize={7}
               />
             )}
           </S.LineWrapper>


### PR DESCRIPTION
- Add several `VictoryTooltip` props to fix the tooltip being cropped under the left side navigation when view a bar on the left side of the graph . 


Preview:
![Screen Shot 2022-06-23 at 5 22 36 PM](https://user-images.githubusercontent.com/26633909/175405131-dca7194e-af04-46d5-a1b6-73d774e0fca7.png)

Closes #15707
