### PR TITLE
Resolve: 15789 Add the no data graphic to the "searches" page when no data is available

### DIFF
--- a/frontend/src/Components/Charts/ChartSections/EmptyChartMessage.js
+++ b/frontend/src/Components/Charts/ChartSections/EmptyChartMessage.js
@@ -16,6 +16,10 @@ function EmptyChartMessage({ data }) {
             if (data.every((arr) => arr.data.length === 0)) {
                 return <EmptyMessage/>
             }
+             // For charts that have a list of data but all y values are 0
+            else if ((data.every((arr) => arr.data.every((a) => a.y === 0)))) {
+                return <EmptyMessage/>
+            }
         }
         // For charts that show data by 'y' values
         else if (data[0].hasOwnProperty("y")) {


### PR DESCRIPTION
- Improve logic of checking if graphs have valid data

Preview: (Previously Searches did not show the Empty Data alert banner)
![Screen Shot 2022-06-28 at 10 52 47 AM](https://user-images.githubusercontent.com/26633909/176211378-aa25aeb0-994b-4705-8f15-1f08e4c25123.png)

Closes #15789