### PR TITLE
Resolve: Consolidate table rows by year and add totals

### DIFF
--- a/frontend/src/Components/Charts/Contraband/Contraband.js
+++ b/frontend/src/Components/Charts/Contraband/Contraband.js
@@ -14,6 +14,7 @@ import {
   reduceYearsToTotal,
   calculatePercentage,
   getQuantityForYear,
+  calculateYearTotal,
 } from '../chartUtils';
 
 // Hooks
@@ -169,5 +170,9 @@ const TABLE_COLUMNS = [
   {
     Header: 'Hispanic',
     accessor: 'hispanic',
+  },
+  {
+    Header: 'Total',
+    accessor: (row) => calculateYearTotal(row),
   },
 ];

--- a/frontend/src/Components/Charts/SearchRate/SearchRate.js
+++ b/frontend/src/Components/Charts/SearchRate/SearchRate.js
@@ -22,6 +22,7 @@ import {
   getRatesAgainstBase,
   STOP_TYPES,
   calculateAveragePercentage,
+  calculateYearTotal,
 } from '../chartUtils';
 import { AGENCY_LIST_SLUG, SEARCHES_SLUG } from '../../../Routes/slugs';
 
@@ -245,5 +246,9 @@ const TABLE_COLUMNS = [
   {
     Header: 'Other*',
     accessor: 'other',
+  },
+  {
+    Header: 'Total',
+    accessor: (row) => calculateYearTotal(row),
   },
 ];

--- a/frontend/src/Components/Charts/Searches/Searches.js
+++ b/frontend/src/Components/Charts/Searches/Searches.js
@@ -9,6 +9,7 @@ import { useParams } from 'react-router-dom';
 // Util
 import {
   AVERAGE,
+  calculateYearTotal,
   filterDataBySearchType,
   getSearchRateForYearByGroup,
   reduceStopReasonsByEthnicity,
@@ -279,6 +280,10 @@ const PERCENTAGE_COLUMNS = [
     Header: 'Other*',
     accessor: 'other',
   },
+  {
+    Header: 'Total',
+    accessor: (row) => calculateYearTotal(row),
+  },
 ];
 
 const COUNT_COLUMNS = [
@@ -313,5 +318,9 @@ const COUNT_COLUMNS = [
   {
     Header: 'Other*',
     accessor: 'other',
+  },
+  {
+    Header: 'Total',
+    accessor: (row) => calculateYearTotal(row),
   },
 ];

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -376,4 +376,8 @@ const BY_REASON_TABLE_COLUMNS = [
     Header: 'Other*',
     accessor: 'other',
   },
+  {
+    Header: 'Total',
+    accessor: (row) => calculateYearTotal(row),
+  },
 ];

--- a/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
+++ b/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
@@ -214,4 +214,8 @@ const TABLE_COLUMNS = [
     Header: 'Hispanic',
     accessor: 'hispanic',
   },
+  {
+    Header: 'Total',
+    accessor: (row) => calculateYearTotal(row),
+  },
 ];

--- a/frontend/src/Components/Charts/chartUtils.js
+++ b/frontend/src/Components/Charts/chartUtils.js
@@ -176,6 +176,24 @@ export const reduceStopReasonsByEthnicity = (data, yearsSet, ethnicGroup, search
     return tick;
   });
 
+export const reduceEthnicityByYears = (data, yearsSet, ethnicGroups = RACES) => {
+  const yearData = [];
+  yearsSet.forEach((yr) => {
+    const yrData = {
+      purpose: '',
+    };
+    yrData.year = yr;
+    const yrSet = data.filter((d) => d.year === yr);
+    ethnicGroups.forEach((e) => {
+      yrData[e] = yrSet.reduce((acc, curr) => ({
+        [e]: acc[e] + curr[e],
+      }))[e];
+    });
+    yearData.push(yrData);
+  });
+  return yearData;
+};
+
 export const getGroupValueBasedOnYear = (data, group, yr, keys) => {
   const groupedData = {};
   keys.forEach((k) => {

--- a/frontend/src/Components/Elements/Table/TableModal.js
+++ b/frontend/src/Components/Elements/Table/TableModal.js
@@ -95,7 +95,7 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
             if (ethnicGroup === 'year') {
               yearData.year = searchDatum;
             } else {
-              yearData[ethnicGroup] = `${stopDatum}`;
+              yearData[ethnicGroup] = stopDatum;
             }
           }
         }
@@ -132,7 +132,7 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
             if (ethnicGroup === 'year') {
               yearData.year = searchDatum;
             } else {
-              yearData[ethnicGroup] = `${searchDatum}`;
+              yearData[ethnicGroup] = searchDatum;
             }
           }
         }
@@ -168,7 +168,7 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
         if (!yearsSearches) groupsSearches = 0;
         else if (!yearsSearches[key]) groupsSearches = 0;
         else groupsSearches = yearsSearches[key];
-        comparedData[key] = `${groupsSearches}`;
+        comparedData[key] = groupsSearches;
       });
       return comparedData;
     });
@@ -194,7 +194,7 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
       const hits = contraband.find((d) => d.year === year) || 0;
       const comparedData = { year };
       RACES.forEach((r) => {
-        comparedData[r] = `${hits[r] || 0}`;
+        comparedData[r] = hits[r] || 0;
       });
       return comparedData;
     });


### PR DESCRIPTION
- Add chartUtil method: `reduceEthnicityByYears` to consolidate ethnicity date by year
- Add `Total` column to view row totals.
- Add option to consolidate data, split by traffic stop type, search type, etc. to view year totals faster than having to manually calculate. 

Preview:
![Screen Shot 2022-07-26 at 8 15 01 PM](https://user-images.githubusercontent.com/26633909/181133869-43f4d8c7-7e7f-4c28-9277-339bcc23d38b.png)
