### PR TITLE
Resolve: 16211 Consolidated Year Total is missing from exports

### DIFF
--- a/frontend/src/Components/Charts/Contraband/Contraband.js
+++ b/frontend/src/Components/Charts/Contraband/Contraband.js
@@ -11,7 +11,6 @@ import {
   reduceYearsToTotal,
   calculatePercentage,
   getQuantityForYear,
-  calculateYearTotal,
 } from '../chartUtils';
 
 // Hooks
@@ -170,6 +169,6 @@ const TABLE_COLUMNS = [
   },
   {
     Header: 'Total',
-    accessor: (row) => calculateYearTotal(row),
+    accessor: 'total',
   },
 ];

--- a/frontend/src/Components/Charts/SearchRate/SearchRate.js
+++ b/frontend/src/Components/Charts/SearchRate/SearchRate.js
@@ -22,7 +22,6 @@ import {
   getRatesAgainstBase,
   STOP_TYPES,
   calculateAveragePercentage,
-  calculateYearTotal,
 } from '../chartUtils';
 import { AGENCY_LIST_SLUG, SEARCHES_SLUG } from '../../../Routes/slugs';
 
@@ -249,6 +248,6 @@ const TABLE_COLUMNS = [
   },
   {
     Header: 'Total',
-    accessor: (row) => calculateYearTotal(row),
+    accessor: 'total',
   },
 ];

--- a/frontend/src/Components/Charts/Searches/Searches.js
+++ b/frontend/src/Components/Charts/Searches/Searches.js
@@ -6,7 +6,6 @@ import { useTheme } from 'styled-components';
 // Util
 import {
   AVERAGE,
-  calculateYearTotal,
   filterDataBySearchType,
   getSearchRateForYearByGroup,
   reduceStopReasonsByEthnicity,
@@ -279,7 +278,7 @@ const PERCENTAGE_COLUMNS = [
   },
   {
     Header: 'Total',
-    accessor: (row) => calculateYearTotal(row),
+    accessor: 'total',
   },
 ];
 
@@ -318,6 +317,6 @@ const COUNT_COLUMNS = [
   },
   {
     Header: 'Total',
-    accessor: (row) => calculateYearTotal(row),
+    accessor: 'total',
   },
 ];

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -3,9 +3,6 @@ import TrafficStopsStyled from './TrafficStops.styled';
 import * as S from '../ChartSections/ChartsCommon.styled';
 import { useTheme } from 'styled-components';
 
-// Router
-// import { useParams } from 'react-router-dom';
-
 // Util
 import {
   reduceFullDataset,
@@ -340,7 +337,7 @@ const STOPS_TABLE_COLUMNS = [
   },
   {
     Header: 'Total',
-    accessor: (row) => calculateYearTotal(row),
+    accessor: 'total',
   },
 ];
 
@@ -379,6 +376,6 @@ const BY_REASON_TABLE_COLUMNS = [
   },
   {
     Header: 'Total',
-    accessor: (row) => calculateYearTotal(row),
+    accessor: 'total',
   },
 ];

--- a/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
+++ b/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
@@ -213,6 +213,6 @@ const TABLE_COLUMNS = [
   },
   {
     Header: 'Total',
-    accessor: (row) => calculateYearTotal(row),
+    accessor: 'total',
   },
 ];

--- a/frontend/src/Components/Charts/chartUtils.js
+++ b/frontend/src/Components/Charts/chartUtils.js
@@ -179,9 +179,7 @@ export const reduceStopReasonsByEthnicity = (data, yearsSet, ethnicGroup, search
 export const reduceEthnicityByYears = (data, yearsSet, ethnicGroups = RACES) => {
   const yearData = [];
   yearsSet.forEach((yr) => {
-    const yrData = {
-      purpose: '',
-    };
+    const yrData = {};
     yrData.year = yr;
     const yrSet = data.filter((d) => d.year === yr);
     ethnicGroups.forEach((e) => {
@@ -189,6 +187,7 @@ export const reduceEthnicityByYears = (data, yearsSet, ethnicGroups = RACES) => 
         [e]: acc[e] + curr[e],
       }))[e];
     });
+    yrData['total'] = calculateYearTotal(yrData);
     yearData.push(yrData);
   });
   return yearData;

--- a/frontend/src/Components/Elements/Table/TableModal.js
+++ b/frontend/src/Components/Elements/Table/TableModal.js
@@ -23,6 +23,7 @@ import {
   STOP_TYPES,
   SEARCH_TYPES,
   reduceEthnicityByYears,
+  calculateYearTotal,
 } from '../../Charts/chartUtils';
 
 // Hooks
@@ -105,6 +106,7 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
               }
             }
           }
+          yearData['total'] = calculateYearTotal(yearData);
           return yearData;
         });
         if (purpose) {
@@ -117,6 +119,7 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
       year: '',
       purpose: 'Totals',
       ...reduceFullDatasetOnlyTotals(mergedData, RACES),
+      total: calculateYearTotal(reduceFullDatasetOnlyTotals(mergedData, RACES)),
     };
     const sortedData = mergedData.sort((a, b) =>
       // Sort data descending by year
@@ -147,6 +150,7 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
               }
             }
           }
+          yearData['total'] = calculateYearTotal(yearData);
           return yearData;
         });
         if (purpose) {
@@ -159,6 +163,7 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
       year: '',
       purpose: 'Totals',
       ...reduceFullDatasetOnlyTotals(mergedData, RACES),
+      total: calculateYearTotal(reduceFullDatasetOnlyTotals(mergedData, RACES)),
     };
     const sortedData = mergedData.sort((a, b) =>
       // Sort data descending by year
@@ -183,6 +188,7 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
         else groupsSearches = yearsSearches[key];
         comparedData[key] = groupsSearches;
       });
+      comparedData['total'] = calculateYearTotal(comparedData);
       return comparedData;
     });
     if (purpose) {
@@ -191,6 +197,7 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
     const raceTotals = {
       year: 'Totals',
       ...reduceFullDatasetOnlyTotals(mergedData, RACES),
+      total: calculateYearTotal(reduceFullDatasetOnlyTotals(mergedData, RACES)),
     };
     const sortedData = mergedData.sort((a, b) =>
       // Sort data descending by year
@@ -209,11 +216,13 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
       RACES.forEach((r) => {
         comparedData[r] = hits[r] || 0;
       });
+      comparedData['total'] = calculateYearTotal(comparedData);
       return comparedData;
     });
     const raceTotals = {
       year: 'Totals',
       ...reduceFullDatasetOnlyTotals(mappedData, RACES),
+      total: calculateYearTotal(reduceFullDatasetOnlyTotals(mappedData, RACES)),
     };
     const sortedData = mappedData.sort((a, b) =>
       // Sort data descending by year
@@ -225,6 +234,8 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
 
   const mapSearchByType = (ds) => {
     const data = chartState.data[ds];
+    // eslint-disable-next-line no-param-reassign,no-return-assign
+    data.forEach((datum) => (datum['total'] = calculateYearTotal(datum)));
     let mappedData = [];
     if (consolidateYears && !purpose) {
       mappedData = reduceEthnicityByYears(data, chartState.yearRange);
@@ -237,6 +248,7 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
       year: 'Totals',
       search_type: '',
       ...reduceFullDatasetOnlyTotals(mappedData, RACES),
+      total: calculateYearTotal(reduceFullDatasetOnlyTotals(mappedData, RACES)),
     };
     const sortedData = mappedData.sort((a, b) =>
       // Sort data descending by year
@@ -260,9 +272,12 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
       data = mapSearchesByReason(ds);
     } else {
       const chartData = chartState.data[ds];
+      // eslint-disable-next-line no-param-reassign,no-return-assign
+      chartData.forEach((chartDatum) => (chartDatum['total'] = calculateYearTotal(chartDatum)));
       const raceTotals = {
         year: 'Totals',
         ...reduceFullDatasetOnlyTotals(chartData, RACES),
+        total: calculateYearTotal(reduceFullDatasetOnlyTotals(chartData, RACES)),
       };
       const sortedData = chartData.sort((a, b) =>
         // Sort data descending by year


### PR DESCRIPTION
- Previously the row total would be calculated on the fly by react-table which prevented the count from showing up in the csv download. 
- Now, we manually calculate the total as before, but also the download has the totals as well. 

Preview:
![Screen Shot 2022-08-11 at 12 59 12 PM](https://user-images.githubusercontent.com/26633909/184191335-6629aabd-08df-4163-a937-fd14e241d1e8.png)

Closes #16211

