### PR TITLE
Resolve: 16208 Graph rendering cropped out of view for certain data sets

### DIFF
--- a/frontend/src/Components/AgencyData/AgencyData.js
+++ b/frontend/src/Components/AgencyData/AgencyData.js
@@ -58,7 +58,11 @@ function AgencyData(props) {
               exit={{ opacity: 0.35, x: '-100%', duration: 750 }}
               transition={{ ease: 'easeIn' }}
             >
-              <Sidebar open={sidebarOpen} setSidebarOpen={setSidebarOpen} />
+              <Sidebar
+                open={sidebarOpen}
+                setSidebarOpen={setSidebarOpen}
+                showCompare={props.showCompare}
+              />
             </motion.div>
           )}
         </AnimatePresence>

--- a/frontend/src/Components/AgencyData/AgencyData.styled.js
+++ b/frontend/src/Components/AgencyData/AgencyData.styled.js
@@ -7,8 +7,8 @@ export const AgencyData = styled(MainBase)``;
 
 export const ContentWrapper = styled.div`
   display: flex;
-  flex-direction: row;
-  width: ${(props) => (props.showCompare ? 'fit-content' : '100%')};
+  flex-direction: ${(props) => (props.showCompare ? 'column' : 'row')};
+  width: 100%;
 
   @media (${smallerThanTabletLandscape}) {
     flex-direction: column;

--- a/frontend/src/Components/Charts/ChartSections/ChartPageBase.styled.js
+++ b/frontend/src/Components/Charts/ChartSections/ChartPageBase.styled.js
@@ -4,14 +4,15 @@ import { phoneOnly, smallerThanDesktop } from '../../../styles/breakpoints';
 
 export const ChartPageBase = styled(motion.article)`
   flex: 1;
-  overflow-y: scroll;
-  align-self: flex-start;
   height: 100%;
+  overflow: hidden;
+  width: 100%;
 `;
 
 export const ChartPageContent = styled.div`
   margin: 0 auto;
   padding: 1.5em 6em 3em 4em;
+  overflow: hidden;
 
   @media (${smallerThanDesktop}) {
     overflow-y: visible;

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -246,15 +246,15 @@ function TrafficStops(props) {
                 yAxisLabel={(val) => `${val}%`}
               />
             </S.LineWrapper>
-            <S.LegendBelow>
+            <S.LegendBeside>
               <Legend
                 heading="Show on graph:"
                 keys={percentageEthnicGroups}
                 onKeySelect={handlePercentageKeySelected}
                 showNonHispanic
-                row
+                row={!props.showCompare}
               />
-            </S.LegendBelow>
+            </S.LegendBeside>
           </S.LineSection>
           <S.PieSection>
             <S.PieWrapper>

--- a/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
+++ b/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
@@ -158,7 +158,7 @@ function UseOfForce(props) {
                 keys={ethnicGroupKeys}
                 onKeySelect={handleGroupKeySelected}
                 showNonHispanic
-                row
+                row={!props.showCompare}
               />
             </S.LegendBelow>
           </S.LineSection>

--- a/frontend/src/Components/Sidebar/Sidebar.js
+++ b/frontend/src/Components/Sidebar/Sidebar.js
@@ -11,7 +11,7 @@ import useOfficerId from '../../Hooks/useOfficerId';
 // Children
 import SidebarLink from './SidebarLink';
 
-function Sidebar() {
+function Sidebar(props) {
   const match = useRouteMatch();
   const officerId = useOfficerId();
 
@@ -23,9 +23,11 @@ function Sidebar() {
   };
 
   return (
-    <S.Sidebar data-testid="Sidebar">
-      <S.Heading>{officerId !== null ? 'Officer' : 'Department'} Data</S.Heading>
-      <S.SidebarNav>
+    <S.Sidebar data-testid="Sidebar" showCompare={props.showCompare}>
+      <S.Heading showCompare={props.showCompare}>
+        {officerId !== null ? 'Officer' : 'Department'} Data
+      </S.Heading>
+      <S.SidebarNav showCompare={props.showCompare}>
         <SidebarLink data-testid="OverviewNavLink" to={buildUrl(slugs.OVERVIEW_SLUG)}>
           Overview
         </SidebarLink>

--- a/frontend/src/Components/Sidebar/Sidebar.styled.js
+++ b/frontend/src/Components/Sidebar/Sidebar.styled.js
@@ -7,14 +7,14 @@ export const Sidebar = styled(motion.div)`
   flex-direction: column;
   background: ${(props) => props.theme.colors.greySemi};
 
-  width: 204px;
+  width: ${(props) => (props.showCompare ? '100%' : '204px')};
   height: 100%;
 
   overflow-x: hidden;
   overflow-y: scroll;
 
   margin-top: 2px;
-  padding: 2em 0 0 2em;
+  padding: ${(props) => (props.showCompare ? '1em' : '2em 0 0 2em;')};
 
   @media (${smallerThanTabletLandscape}) {
     width: 100%;
@@ -37,6 +37,7 @@ export const Heading = styled.p`
   font-family: ${(props) => props.theme.fonts.heading};
   font-size: 16px;
   margin-bottom: 1em;
+  ${(props) => (props.showCompare ? 'display: none;' : '')}
 
   @media (${smallerThanTabletLandscape}) {
     display: none;
@@ -46,7 +47,8 @@ export const Heading = styled.p`
 export const SidebarNav = styled.ul`
   flex: 1;
   display: flex;
-  flex-direction: column;
+  flex-direction: ${(props) => (props.showCompare ? 'row' : 'column')};
+  ${(props) => (props.showCompare ? 'justify-content: space-around;\n  align-items: center' : '')};
   @media (${smallerThanTabletLandscape}) {
     flex-direction: row;
     justify-content: space-around;


### PR DESCRIPTION
- When the compare agencies features was merged. The left side of the graphs were harder to read than the left. 
- With these changes, we simply move the sidebar to the top of the left view to increase the width and hopefully make it easier to read the data from. 

Preview:
![Screen Shot 2022-08-11 at 1 50 13 PM](https://user-images.githubusercontent.com/26633909/184201876-4f3b74c8-3c5b-49c8-808b-2f02a181b22a.png)


Closes #16208
