### PR TITLE
Fixed changing height in header

### DIFF
--- a/frontend/src/Components/Header/Header.styled.js
+++ b/frontend/src/Components/Header/Header.styled.js
@@ -9,13 +9,17 @@ export const Header = styled.header`
   border-bottom-color: ${(props) => props.theme.colors.border};
   background: ${(props) => props.theme.colors.primary};
   height: 80px;
+  min-height: 5rem;
+  max-height: 5rem;
 
   @media (${breakpoints.smallerThanTabletLandscape}) {
-    height: 140px;
+    min-height: 8.75rem;
+    max-height: 8.75rem;
   }
 
   @media (${breakpoints.phoneOnly}) {
-    height: 180px;
+    min-height: 11.25rem;
+    max-height: 11.25rem;
   }
 `;
 


### PR DESCRIPTION
Fixed issue FJ-107: https://app.clickup.com/t/3zy0n88

Found that setting the min and max height for the header file fixed this issue. The problem was because the the AgencyHeader and ChartPageBase would be too tall and squeeze the height out of the header. Setting the min-height seemed to fix the problem but I also set the max-height so that the padding looked correct. 

I used rem units to avoid the padding issues from occurring when changing the zoom resolution on the window as we.. 