### PR TITLE
Conditionally show dropdown direction on mobile screens

### DIFF
--- a/frontend/src/Components/Charts/Contraband/Contraband.js
+++ b/frontend/src/Components/Charts/Contraband/Contraband.js
@@ -27,7 +27,7 @@ import ChartHeader from '../ChartSections/ChartHeader';
 import DataSubsetPicker from '../ChartSections/DataSubsetPicker/DataSubsetPicker';
 
 function SearchRate(props) {
-  const { agencyId } = props;
+  const { agencyId, showCompare } = props;
   const theme = useTheme();
 
   const [chartState] = useDataset(agencyId, CONTRABAND_HIT_RATE);
@@ -90,7 +90,7 @@ function SearchRate(props) {
             Shows what percentage of searches discovered contraband for a given race / ethnic group
           </P>
         </S.ChartDescription>
-        <S.ChartSubsection showCompare={props.showCompare}>
+        <S.ChartSubsection showCompare={showCompare}>
           <S.LineSection>
             <S.LineWrapper>
               <Bar
@@ -128,6 +128,7 @@ function SearchRate(props) {
               value={year}
               onChange={handleYearSelect}
               options={[YEARS_DEFAULT].concat(chartState.yearRange)}
+              dropUp={!!showCompare}
             />
           </S.LegendSection>
         </S.ChartSubsection>

--- a/frontend/src/Components/Charts/SearchRate/SearchRate.js
+++ b/frontend/src/Components/Charts/SearchRate/SearchRate.js
@@ -34,7 +34,7 @@ import GroupedBar from '../ChartPrimitives/GroupedBar';
 import { VictoryLabel } from 'victory';
 
 function SearchRate(props) {
-  const { agencyId } = props;
+  const { agencyId, showCompare } = props;
   const theme = useTheme();
   const history = useHistory();
   const officerId = useOfficerId();
@@ -151,7 +151,7 @@ function SearchRate(props) {
             incidents. Use “View Data” to see the numbers underlying the calculations.
           </P>
         </S.ChartDescription>
-        <S.ChartSubsection showCompare={props.showCompare}>
+        <S.ChartSubsection showCompare={showCompare}>
           <S.LineWrapper>
             {noBaseSearches ? (
               <S.NoBaseSearches>
@@ -202,6 +202,7 @@ function SearchRate(props) {
                 value={year}
                 onChange={handleYearSelected}
                 options={[YEARS_DEFAULT].concat(chartState.yearRange)}
+                dropUp={!!showCompare}
               />
             </S.Spacing>
           </S.LegendBelow>

--- a/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
+++ b/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
@@ -31,7 +31,7 @@ import GroupedBar from '../ChartPrimitives/GroupedBar';
 import Pie from '../ChartPrimitives/Pie';
 
 function UseOfForce(props) {
-  const { agencyId } = props;
+  const { agencyId, showCompare } = props;
   const officerId = useOfficerId();
   const theme = useTheme();
 
@@ -138,7 +138,7 @@ function UseOfForce(props) {
             against
           </P>
         </S.ChartDescription>
-        <S.ChartSubsection showCompare={props.showCompare}>
+        <S.ChartSubsection showCompare={showCompare}>
           <S.LineSection>
             <S.LineWrapper>
               <GroupedBar


### PR DESCRIPTION
For subpages in an angency, Contraband & Use of Force, the dropdown for the graph was cutoff at the bottom. 