### PR TITLE
Hide white checkbox for Search Rate

### DIFF
--- a/frontend/src/Components/Charts/SearchRate/SearchRate.js
+++ b/frontend/src/Components/Charts/SearchRate/SearchRate.js
@@ -43,7 +43,7 @@ function SearchRate(props) {
 
   const [year, setYear] = useState(YEARS_DEFAULT);
   const [ethnicGroupKeys, setEthnicGroupKeys] = useState(() =>
-    STATIC_LEGEND_KEYS.map((k) => ({ ...k }))
+    STATIC_LEGEND_KEYS.map((k) => ({ ...k })).filter((k) => k.value !== 'white')
   );
 
   const [chartData, setChartData] = useState([]);


### PR DESCRIPTION
The white checkbox had no effect on updating the Search Rate graph. 