### PR TITLE
Remove fixed header

### DIFF
--- a/frontend/src/Components/App.js
+++ b/frontend/src/Components/App.js
@@ -62,7 +62,7 @@ function App() {
               <Header />
               <Switch>
                 <Route path={`${AGENCY_LIST_SLUG}/:agencyId`}>
-                  <div style={{ display: 'flex', overflowY: 'auto' }}>
+                  <div style={{ display: 'flex', height: '100%' }}>
                     <ChartStateProvider reducer={chartReducer} initialState={initialChartState}>
                       <AgencyData showCompare={showCompare} toggleShowCompare={toggleShowCompare} />
                     </ChartStateProvider>

--- a/frontend/src/Components/Elements/Table/TableModal.js
+++ b/frontend/src/Components/Elements/Table/TableModal.js
@@ -68,6 +68,7 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
   useEffect(() => {
     function _handleKeyUp(e) {
       if (e.key === 'Escape') {
+        document.body.style.overflow = 'visible';
         closeModal();
       }
     }
@@ -77,10 +78,13 @@ function TableModal({ chartState, dataSet, columns, isOpen, closeModal }) {
 
   // supress body scrolling behind modal
   useEffect(() => {
-    document.body.style.overflow = 'hidden';
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    }
+
     // eslint-disable-next-line no-return-assign
     return () => (document.body.style.overflow = 'visible');
-  }, []);
+  }, [isOpen]);
 
   /* Build some more complicated data sets */
   const mapStopsByPurpose = (ds) => {

--- a/frontend/src/Components/Header/Header.styled.js
+++ b/frontend/src/Components/Header/Header.styled.js
@@ -3,7 +3,6 @@ import * as breakpoints from '../../styles/breakpoints';
 import { motion } from 'framer-motion';
 
 export const Header = styled.header`
-  position: relative;
   width: 100%;
   border-bottom: ${(props) => props.theme.borders.standard};
   border-bottom-color: ${(props) => props.theme.colors.border};

--- a/frontend/src/Components/Layout.styled.js
+++ b/frontend/src/Components/Layout.styled.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export default styled.div`
   width: 100%;
   display: flex;
+  flex: 1;
   flex-direction: column;
-  max-height: 100vh;
+  max-height: 100%;
 `;


### PR DESCRIPTION
- On mobile, the header took up too much space when scrolling. 
- Like the footer, keep the header at the top of the page and not pin the position to the top when scrolling. 