### PR TITLE
Adding a loading screen for find a stop page

### DIFF
--- a/frontend/src/Components/Elements/Skeletons/TableSkeleton.js
+++ b/frontend/src/Components/Elements/Skeletons/TableSkeleton.js
@@ -1,71 +1,75 @@
 import React from 'react';
 import LoaderBase from './LoaderBase';
 import ContentLoader from 'react-content-loader';
+import { H1C } from '../../../styles/StyledComponents/Typography';
 
 function TableSkeleton(props) {
   return (
-    <LoaderBase>
-      <ContentLoader
-        width={1000}
-        height={550}
-        viewBox="0 0 1000 550"
-        backgroundColor="#eaeced"
-        foregroundColor="#ffffff"
-        {...props}
-      >
-        <rect x="51" y="45" rx="3" ry="3" width="906" height="17" />
-        <circle cx="879" cy="123" r="11" />
-        <circle cx="914" cy="123" r="11" />
-        <rect x="104" y="115" rx="3" ry="3" width="141" height="15" />
-        <rect x="305" y="114" rx="3" ry="3" width="299" height="15" />
-        <rect x="661" y="114" rx="3" ry="3" width="141" height="15" />
-        <rect x="55" y="155" rx="3" ry="3" width="897" height="2" />
-        <circle cx="880" cy="184" r="11" />
-        <circle cx="915" cy="184" r="11" />
-        <rect x="105" y="176" rx="3" ry="3" width="141" height="15" />
-        <rect x="306" y="175" rx="3" ry="3" width="299" height="15" />
-        <rect x="662" y="175" rx="3" ry="3" width="141" height="15" />
-        <rect x="56" y="216" rx="3" ry="3" width="897" height="2" />
-        <circle cx="881" cy="242" r="11" />
-        <circle cx="916" cy="242" r="11" />
-        <rect x="106" y="234" rx="3" ry="3" width="141" height="15" />
-        <rect x="307" y="233" rx="3" ry="3" width="299" height="15" />
-        <rect x="663" y="233" rx="3" ry="3" width="141" height="15" />
-        <rect x="57" y="274" rx="3" ry="3" width="897" height="2" />
-        <circle cx="882" cy="303" r="11" />
-        <circle cx="917" cy="303" r="11" />
-        <rect x="107" y="295" rx="3" ry="3" width="141" height="15" />
-        <rect x="308" y="294" rx="3" ry="3" width="299" height="15" />
-        <rect x="664" y="294" rx="3" ry="3" width="141" height="15" />
-        <rect x="58" y="335" rx="3" ry="3" width="897" height="2" />
-        <circle cx="881" cy="363" r="11" />
-        <circle cx="916" cy="363" r="11" />
-        <rect x="106" y="355" rx="3" ry="3" width="141" height="15" />
-        <rect x="307" y="354" rx="3" ry="3" width="299" height="15" />
-        <rect x="663" y="354" rx="3" ry="3" width="141" height="15" />
-        <rect x="57" y="395" rx="3" ry="3" width="897" height="2" />
-        <circle cx="882" cy="424" r="11" />
-        <circle cx="917" cy="424" r="11" />
-        <rect x="107" y="416" rx="3" ry="3" width="141" height="15" />
-        <rect x="308" y="415" rx="3" ry="3" width="299" height="15" />
-        <rect x="664" y="415" rx="3" ry="3" width="141" height="15" />
-        <rect x="55" y="453" rx="3" ry="3" width="897" height="2" />
-        <rect x="51" y="49" rx="3" ry="3" width="2" height="465" />
-        <rect x="955" y="49" rx="3" ry="3" width="2" height="465" />
-        <circle cx="882" cy="484" r="11" />
-        <circle cx="917" cy="484" r="11" />
-        <rect x="107" y="476" rx="3" ry="3" width="141" height="15" />
-        <rect x="308" y="475" rx="3" ry="3" width="299" height="15" />
-        <rect x="664" y="475" rx="3" ry="3" width="141" height="15" />
-        <rect x="55" y="513" rx="3" ry="3" width="897" height="2" />
-        <rect x="52" y="80" rx="3" ry="3" width="906" height="17" />
-        <rect x="53" y="57" rx="3" ry="3" width="68" height="33" />
-        <rect x="222" y="54" rx="3" ry="3" width="149" height="33" />
-        <rect x="544" y="55" rx="3" ry="3" width="137" height="33" />
-        <rect x="782" y="56" rx="3" ry="3" width="72" height="33" />
-        <rect x="933" y="54" rx="3" ry="3" width="24" height="33" />
-      </ContentLoader>
-    </LoaderBase>
+    <>
+      <H1C>Loading</H1C>
+      <LoaderBase>
+        <ContentLoader
+          width={1000}
+          height={550}
+          viewBox="0 0 1000 550"
+          backgroundColor="#eaeced"
+          foregroundColor="#ffffff"
+          {...props}
+        >
+          <rect x="51" y="45" rx="3" ry="3" width="906" height="17" />
+          <circle cx="879" cy="123" r="11" />
+          <circle cx="914" cy="123" r="11" />
+          <rect x="104" y="115" rx="3" ry="3" width="141" height="15" />
+          <rect x="305" y="114" rx="3" ry="3" width="299" height="15" />
+          <rect x="661" y="114" rx="3" ry="3" width="141" height="15" />
+          <rect x="55" y="155" rx="3" ry="3" width="897" height="2" />
+          <circle cx="880" cy="184" r="11" />
+          <circle cx="915" cy="184" r="11" />
+          <rect x="105" y="176" rx="3" ry="3" width="141" height="15" />
+          <rect x="306" y="175" rx="3" ry="3" width="299" height="15" />
+          <rect x="662" y="175" rx="3" ry="3" width="141" height="15" />
+          <rect x="56" y="216" rx="3" ry="3" width="897" height="2" />
+          <circle cx="881" cy="242" r="11" />
+          <circle cx="916" cy="242" r="11" />
+          <rect x="106" y="234" rx="3" ry="3" width="141" height="15" />
+          <rect x="307" y="233" rx="3" ry="3" width="299" height="15" />
+          <rect x="663" y="233" rx="3" ry="3" width="141" height="15" />
+          <rect x="57" y="274" rx="3" ry="3" width="897" height="2" />
+          <circle cx="882" cy="303" r="11" />
+          <circle cx="917" cy="303" r="11" />
+          <rect x="107" y="295" rx="3" ry="3" width="141" height="15" />
+          <rect x="308" y="294" rx="3" ry="3" width="299" height="15" />
+          <rect x="664" y="294" rx="3" ry="3" width="141" height="15" />
+          <rect x="58" y="335" rx="3" ry="3" width="897" height="2" />
+          <circle cx="881" cy="363" r="11" />
+          <circle cx="916" cy="363" r="11" />
+          <rect x="106" y="355" rx="3" ry="3" width="141" height="15" />
+          <rect x="307" y="354" rx="3" ry="3" width="299" height="15" />
+          <rect x="663" y="354" rx="3" ry="3" width="141" height="15" />
+          <rect x="57" y="395" rx="3" ry="3" width="897" height="2" />
+          <circle cx="882" cy="424" r="11" />
+          <circle cx="917" cy="424" r="11" />
+          <rect x="107" y="416" rx="3" ry="3" width="141" height="15" />
+          <rect x="308" y="415" rx="3" ry="3" width="299" height="15" />
+          <rect x="664" y="415" rx="3" ry="3" width="141" height="15" />
+          <rect x="55" y="453" rx="3" ry="3" width="897" height="2" />
+          <rect x="51" y="49" rx="3" ry="3" width="2" height="465" />
+          <rect x="955" y="49" rx="3" ry="3" width="2" height="465" />
+          <circle cx="882" cy="484" r="11" />
+          <circle cx="917" cy="484" r="11" />
+          <rect x="107" y="476" rx="3" ry="3" width="141" height="15" />
+          <rect x="308" y="475" rx="3" ry="3" width="299" height="15" />
+          <rect x="664" y="475" rx="3" ry="3" width="141" height="15" />
+          <rect x="55" y="513" rx="3" ry="3" width="897" height="2" />
+          <rect x="52" y="80" rx="3" ry="3" width="906" height="17" />
+          <rect x="53" y="57" rx="3" ry="3" width="68" height="33" />
+          <rect x="222" y="54" rx="3" ry="3" width="149" height="33" />
+          <rect x="544" y="55" rx="3" ry="3" width="137" height="33" />
+          <rect x="782" y="56" rx="3" ry="3" width="72" height="33" />
+          <rect x="933" y="54" rx="3" ry="3" width="24" height="33" />
+        </ContentLoader>
+      </LoaderBase>
+    </>
   );
 }
 

--- a/frontend/src/Components/FindAStopResults/FindAStopResults.js
+++ b/frontend/src/Components/FindAStopResults/FindAStopResults.js
@@ -54,15 +54,19 @@ function FindAStopResults() {
   const history = useHistory();
 
   const [stops, setStops] = useState([]);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     async function _fetchStops() {
+      setLoading(true);
       try {
         const { data } = await axios.get(`${FIND_A_STOP_URL}${search}`);
         setStops(data.results);
+        setLoading(false);
       } catch (e) {
         // eslint-disable-next-line no-console
         console.warn(e);
+        setLoading(false);
       }
     }
     _fetchStops();
@@ -86,7 +90,7 @@ function FindAStopResults() {
       <S.Heading>
         <BackButton to={FIND_A_STOP_SLUG} text="Back to Search" />
         <H1>Stops</H1>
-        {stops.length > 0 && (
+        {!loading && stops.length > 0 && (
           <P size={SIZES[0]} color={COLORS[0]}>
             {stops.length === MAX_STOPS_RESULTS
               ? `Returned maximum number of results (${MAX_STOPS_RESULTS}). Try limiting your search`
@@ -95,8 +99,8 @@ function FindAStopResults() {
         )}
       </S.Heading>
       <S.TableContainer>
-        {!stops && <TableSkeleton />}
-        {stops.length === 0 && (
+        {loading && <TableSkeleton />}
+        {!loading && stops.length === 0 && (
           <S.NoResults>
             <H2>No stops matching these criteria have been reported to the SBI.</H2>
             <P>

--- a/frontend/src/styles/StyledComponents/Typography.js
+++ b/frontend/src/styles/StyledComponents/Typography.js
@@ -10,6 +10,17 @@ export const H1 = styled.h1`
   text-transform: uppercase;
 `;
 
+// Centered h1 element
+export const H1C = styled.h1`
+  font-family: ${(props) => props.theme.fonts.heading};
+  font-weight: 400;
+  font-size: 48px;
+  margin: 0.5em 0;
+  color: ${(props) => props.theme.colors.text};
+  text-transform: uppercase;
+  text-align: center;
+`;
+
 export const H1point5 = styled.h2`
   font-family: ${(props) => props.theme.fonts.heading};
   font-weight: 400;


### PR DESCRIPTION
- Add loading hook to show/hide table skeleton so users aren't confused why the no results message shows up when it's in the middle of fetching content. 


Preview:
![Screen Shot 2022-12-01 at 11 15 47 AM](https://user-images.githubusercontent.com/26633909/205104639-a9128b45-de5b-4d92-a275-6ee8b603a941.png)
