### PR TITLE
Add alert box for bad device orientation when comparing departments

### DIFF
--- a/frontend/src/Components/AgencyData/AgencyData.js
+++ b/frontend/src/Components/AgencyData/AgencyData.js
@@ -14,6 +14,7 @@ import useDataset, { AGENCY_DETAILS } from '../../Hooks/useDataset';
 import AgencyHeader from './AgencyHeader';
 import Sidebar from '../Sidebar/Sidebar';
 import ChartRoutes from '../Charts/ChartRoutes';
+import { CompareAlertBox } from '../Elements/Alert/Alert';
 
 function AgencyData(props) {
   let { agencyId } = useParams();
@@ -40,6 +41,7 @@ function AgencyData(props) {
 
   return (
     <S.AgencyData data-testid="AgencyData" {...props}>
+      {props.showCompare && !props.agencyId && <CompareAlertBox />}
       <AgencyHeader
         agencyHeaderOpen={agencyHeaderOpen}
         agencyDetails={chartState.data[AGENCY_DETAILS]}

--- a/frontend/src/Components/Elements/Alert/Alert.js
+++ b/frontend/src/Components/Elements/Alert/Alert.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import * as S from './Alert.styled';
+
+function Alert({ message }) {
+  return <div>{message}</div>;
+}
+function AlertBox({ message, color }) {
+  return (
+    <S.Alert color={color}>
+      <Alert message={message} />
+    </S.Alert>
+  );
+}
+
+export function CompareAlertBox() {
+  return (
+    <S.CompareAlert color="red">
+      <Alert message="Please rotate your device to landscape mode for optimum viewing of data" />
+    </S.CompareAlert>
+  );
+}
+
+export default AlertBox;

--- a/frontend/src/Components/Elements/Alert/Alert.styled.js
+++ b/frontend/src/Components/Elements/Alert/Alert.styled.js
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+import { phoneOnly } from '../../../styles/breakpoints';
+
+export const Alert = styled.div`
+  padding: 20px;
+  background-color: ${(props) => props.color};
+  color: white;
+  margin-bottom: 20px;
+  font-weight: bolder;
+  font-size: 22px;
+`;
+
+export const CompareAlert = styled(Alert)`
+  display: none;
+
+  @media (${phoneOnly}) {
+    display: block;
+    position: absolute;
+  }
+`;


### PR DESCRIPTION
- Add `Alert` component
- Add `CompareAlertBox` component that only shows when device is in portrait mode and is comparing agencies. 

Preview:
![Screen Shot 2023-02-07 at 5 29 35 PM](https://user-images.githubusercontent.com/26633909/217381905-6d6d966a-a10c-4883-b76b-bd8d9a5fcf36.png)
