### PR TITLE
Find a stop link cropped on mobile view.

### DIFF
--- a/frontend/src/Components/Elements/LinkButton.js
+++ b/frontend/src/Components/Elements/LinkButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { phoneOnly } from '../../styles/breakpoints';
 
 function LinkButton({ href, title }) {
   return (
@@ -18,4 +19,8 @@ const LinkStyled = styled.a`
   color: white;
   font-weight: 700;
   text-decoration: none;
+
+  @media (${phoneOnly}) {
+    padding: 8px;
+  }
 `;

--- a/frontend/src/Components/Header/Navbar.styled.js
+++ b/frontend/src/Components/Header/Navbar.styled.js
@@ -20,6 +20,6 @@ export const Navlink = styled(NavLink)`
   margin: 0 2em;
 
   @media (${breakpoints.phoneOnly}) {
-    margin: 0 1em;
+    margin: 0 0.5em;
   }
 `;

--- a/frontend/src/Components/ResourcePage/ResourcePage.js
+++ b/frontend/src/Components/ResourcePage/ResourcePage.js
@@ -10,7 +10,7 @@ function Resource({ resource }) {
   return (
     <S.ResourceBlock>
       <div style={{ marginRight: '20px' }}>
-        <img src={resource.image_url} width={150} alt={resource.title} />
+        <S.ResourceImage src={resource.image_url} alt={resource.title} />
       </div>
       <div>
         <H3>{resource.title} </H3>

--- a/frontend/src/Components/ResourcePage/ResourcePage.styled.js
+++ b/frontend/src/Components/ResourcePage/ResourcePage.styled.js
@@ -1,5 +1,9 @@
 import styled from 'styled-components';
-import { smallerThanDesktop, smallerThanTabletLandscape } from '../../styles/breakpoints';
+import {
+  phoneOnly,
+  smallerThanDesktop,
+  smallerThanTabletLandscape,
+} from '../../styles/breakpoints';
 import FullWidthPage from '../../styles/StyledComponents/FullWidthPage';
 
 export const ResourcePageStyled = styled(FullWidthPage)``;
@@ -23,6 +27,18 @@ export const ResourceBlock = styled.div`
   display: flex;
   margin-bottom: 50px;
   padding: 30px;
+
+  @media (${phoneOnly}) {
+    padding: 10px;
+  }
+`;
+
+export const ResourceImage = styled.img`
+  width: 150px;
+
+  @media (${phoneOnly}) {
+    width: 75px;
+  }
 `;
 
 export const ResourceDividingLine = styled.div`


### PR DESCRIPTION
- Fix navbar links for mobile
- Cleanup resources view for mobile screens.

Preview:
![Screen Shot 2023-02-21 at 3 19 58 PM](https://user-images.githubusercontent.com/26633909/220449624-5e75e77e-e170-4ea1-aa71-e0e041966377.png)
