### PR TITLE
Deploy descheduler, upgrade Helm charts 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: flake8
         exclude: settings|migrations|tests
   - repo: https://github.com/pycqa/isort
-    rev: 5.6.4
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -92,9 +92,9 @@ k8s_iam_users: [copelco]
 # Pin ingress-nginx and cert-manager to current versions so future upgrades of this
 # role will not upgrade these charts without your intervention:
 # https://github.com/kubernetes/ingress-nginx/releases
-k8s_ingress_nginx_chart_version: "4.0.19"
+k8s_ingress_nginx_chart_version: "4.4.2"
 # https://github.com/jetstack/cert-manager/releases
-k8s_cert_manager_chart_version: "v1.7.2"
+k8s_cert_manager_chart_version: "v1.11.0"
 # AWS only:
 # Use the newer load balancer type (NLB). DO NOT edit k8s_aws_load_balancer_type after
 # creating your Service.

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -94,7 +94,7 @@ k8s_iam_users: [copelco]
 # https://github.com/kubernetes/ingress-nginx/releases
 k8s_ingress_nginx_chart_version: "4.4.2"
 # https://github.com/jetstack/cert-manager/releases
-k8s_cert_manager_chart_version: "v1.11.0"
+k8s_cert_manager_chart_version: "v1.7.2"
 # AWS only:
 # Use the newer load balancer type (NLB). DO NOT edit k8s_aws_load_balancer_type after
 # creating your Service.
@@ -108,7 +108,7 @@ k8s_papertrail_logspout_destination: "syslog+tls://logs2.papertrailapp.com:20851
 k8s_papertrail_logspout_memory_limit: 128Mi
 
 # New Relic Infrastructure: admin+newrelic@caktusgroup.com
-k8s_newrelic_chart_version: "3.5.1"
+k8s_newrelic_chart_version: "5.0.4"
 k8s_newrelic_license_key: !vault |
   $ANSIBLE_VAULT;1.1;AES256
   37656631623333346263383231386165666531333961373931383661366338343634333362356430

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -57,6 +57,21 @@ cloudformation_stack:
   tags:
     Environment: "{{ app_name }}"
 
+# Install Descheduler to attempt to spread out pods again after node failures
+k8s_install_descheduler: yes
+# You must set the k8s_descheduler_chart_version to match the Kubernetes
+# node version (0.23.x -> K8s 1.23.x); see:
+# https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
+k8s_descheduler_chart_version: v0.22.1
+# See values.yaml for options:
+# https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
+k8s_descheduler_release_values:
+  deschedulerPolicy:
+    strategies:
+      # During upgrades or reboots, don't pre-emptively drain a node.
+      RemovePodsViolatingNodeTaints:
+        enabled: false
+
 # ----------------------------------------------------------------------------
 # caktus.k8s-web-cluster: An Ansible role to help configure Kubernetes
 #                         clusters for web apps.

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -14,4 +14,4 @@
 
 - src: https://github.com/caktus/ansible-role-k8s-hosting-services
   name: caktus.k8s-hosting-services
-  version: v0.7.0
+  version: v0.9.0

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -10,7 +10,7 @@
 
 - src: https://github.com/caktus/ansible-role-k8s-web-cluster
   name: caktus.k8s-web-cluster
-  version: v1.3.0
+  version: v1.4.0
 
 - src: https://github.com/caktus/ansible-role-k8s-hosting-services
   name: caktus.k8s-hosting-services


### PR DESCRIPTION
### Issue
- https://app.clickup.com/t/8677fzttd

### Summary
- [x] descheduler chart install: v0.22.1
- [x] ingress-nginx chart upgrade: v4.0.19 → v4.4.2
- [x] cert-manager chart upgrade: v1.7.2 → v1.11.0
- [x] newrelic chart upgrade: v3.5.1 → v5.0.4
- [x] AWS NodeGroup AMI upgrade: 1.22.9-20220620 → 1.22.17-20230217

#### Deploy descheduler

```
❯ inv deploy.install
❯ inv deploy.playbook -n deploy-cluster.yml
❯ kubectl -n kube-system get cronjob
NAME          SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
descheduler   */2 * * * *   False     0        59s             6m11s
```

#### Upgrade ingress-nginx and cert-manager

```
❯ inv deploy.playbook -n deploy-cluster.yml
❯ kubectl -n ingress-nginx get pod -o wide 
NAME                                        READY   STATUS    RESTARTS   AGE     IP            NODE                                        NOMINATED NODE   READINESS GATES
ingress-nginx-controller-7b454df556-ds79n   1/1     Running   0          2m17s   10.0.15.220   ip-10-0-14-203.us-east-2.compute.internal   <none>           <none>
ingress-nginx-controller-7b454df556-z4hl7   1/1     Running   0          117s    10.0.10.241   ip-10-0-10-229.us-east-2.compute.internal   <none>           <none>

❯ helm -n cert-manager list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
cert-manager    cert-manager    4               2023-02-24 21:35:02.727236341 +0000 UTC deployed        cert-manager-v1.7.2     v1.7.2
```

#### Upgrade newrelic chart

```
❯ helm -n newrelic uninstall newrelic-bundle
release "newrelic-bundle" uninstalled
❯ inv production deploy.playbook -n deploy-hosting-services.yml
❯ helm -n newrelic list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
newrelic-bundle newrelic        1               2023-02-24 21:41:36.95967101 +0000 UTC  deployed        nri-bundle-5.0.4                   
```

New nodes running (approx 10 mins 4:50 - 5:00 PM):

![Screenshot 2023-02-24 at 5 00 28 PM](https://user-images.githubusercontent.com/87770895/221301440-33bb5a02-4864-4d99-b716-9c6ad62a2dd6.png)
