### PR TITLE
Only drop index IF EXISTS during import

### DIFF
--- a/tsdata/sql.py
+++ b/tsdata/sql.py
@@ -54,7 +54,7 @@ ORDER BY CASE WHEN contype='f' THEN 0 ELSE 1 END,contype,nspname,relname,conname
 """  # noqa
 
 SELECT_DROP_INDEXES_SQL = """
-SELECT 'DROP INDEX "'||nspname||'"."'||relname||'" RESTRICT;'
+SELECT 'DROP INDEX IF EXISTS "'||nspname||'"."'||relname||'" RESTRICT;'
 FROM pg_index
 INNER JOIN pg_class ON indexrelid=pg_class.oid
 INNER JOIN pg_namespace ON pg_namespace.oid=pg_class.relnamespace


### PR DESCRIPTION
Add `IF EXISTS` drop `DROP INDEX` statements during import.

### Issue
- https://app.clickup.com/t/8677ja8mt

### Investigation

```python
from django.db import connections
from tsdata.sql import drop_constraints_and_indexes, get_sql_statements, SELECT_DROP_CONSTRAINTS_SQL, SELECT_DROP_INDEXES_SQL
with connections["traffic_stops_nc"].cursor() as cursor:
    sql = get_sql_statements(cursor, SELECT_DROP_CONSTRAINTS_SQL)
    sql += get_sql_statements(cursor, SELECT_DROP_INDEXES_SQL)
    print(sql)
```

Generates two DROP statements, so the 2nd one fails:

```sql
-- ...
ALTER TABLE "public"."nc_resource_agencies" DROP CONSTRAINT IF EXISTS "nc_resource_agencies_resource_id_agency_id_2d682e8a_uniq";
-- ...
DROP INDEX "public"."nc_resource_agencies_resource_id_agency_id_2d682e8a_uniq" RESTRICT;
-- ...
```

Perhaps this type of constraint is new and therefore we hadn't seen it before?