### PR TITLE
Hide average from traffic stops dropdown

### DIFF
--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -50,6 +50,9 @@ function TrafficStops(props) {
 
   const [purpose, setPurpose] = useState(PURPOSE_DEFAULT);
 
+  // Don't include Average as that's only used in the Search Rate graph.
+  const stopTypes = STOP_TYPES.filter((st) => st !== 'Average');
+
   const [percentageEthnicGroups, setPercentageEthnicGroups] = useState(
     /* I sure wish I understood with certainty why this is necessary. Here's what I know:
       - Setting both of these states to STATIC_LEGEND_KEYS cause calling either setState function
@@ -292,7 +295,7 @@ function TrafficStops(props) {
               label="Stop Purpose"
               value={purpose}
               onChange={handleStopPurposeSelect}
-              options={[PURPOSE_DEFAULT].concat(STOP_TYPES)}
+              options={[PURPOSE_DEFAULT].concat(stopTypes)}
             />
             <S.Spacing>
               <Legend


### PR DESCRIPTION
- Remove a dropdown item that wasn't supposed to be used in the traffic stops section, only under search rate.

Preview:
![Screen Shot 2023-03-07 at 3 31 54 PM](https://user-images.githubusercontent.com/26633909/223545610-d41c98e3-ea63-4d32-a5ea-93dd7ceae69f.png)
