### PR TITLE
Do not cache resources + save related fields for resources

### DIFF
--- a/nc/admin.py
+++ b/nc/admin.py
@@ -45,13 +45,20 @@ class StopSummaryAdmin(admin.ModelAdmin):
 
 
 class ResourceAdmin(admin.ModelAdmin):
-    list_display = ("title", "created_date",)
+    list_display = (
+        "title",
+        "created_date",
+    )
 
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
         if not obj.image:
             obj.image = "forward-justice-logo"
             obj.save()
+
+    def save_related(self, request, form, formsets, change):
+        super().save_model(request, form, formsets, change)
+        form.instance.agencies.set(form.cleaned_data["agencies"], clear=True)
 
 
 admin.site.register(Agency, AgencyAdmin)

--- a/nc/views.py
+++ b/nc/views.py
@@ -2,6 +2,8 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.db.models import Case, Count, F, Q, Sum, Value, When
 from django.db.models.functions import ExtractYear
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -289,12 +291,17 @@ class ResourcesViewSet(viewsets.ReadOnlyModelViewSet):
     def get_serializer_class(self):
         return serializers.ResourcesSerializer(context={"request": self.request})
 
+    @method_decorator(never_cache)
     def list(self, request, *args, **kwargs):
-        return Response({"results": self.serializer_class(
-            Resource.objects.all(),
-            many=True,
-            context={"request": self.request},
-        ).data})
+        return Response(
+            {
+                "results": self.serializer_class(
+                    Resource.objects.all(),
+                    many=True,
+                    context={"request": self.request},
+                ).data
+            }
+        )
 
 
 class ContactView(APIView):


### PR DESCRIPTION
A bug in staging prevents the resources from updated the list of agencies associated per tag.

- Don't cache the list of resources
- Clear and set the agencies per resource change on save 