### PR TITLE
Truncate materialized view to month

### DIFF
--- a/nc/admin.py
+++ b/nc/admin.py
@@ -13,7 +13,7 @@ class StopSummaryAdmin(admin.ModelAdmin):
     list_display = (
         "id",
         "agency_name",
-        "year",
+        "date",
         "stop_purpose",
         "engage_force",
         "search_type",
@@ -28,7 +28,6 @@ class StopSummaryAdmin(admin.ModelAdmin):
         "engage_force",
         "search_type",
         "contraband_found",
-        "year",
         "agency",
     )
     list_select_related = ("agency",)

--- a/nc/models.py
+++ b/nc/models.py
@@ -168,8 +168,7 @@ STOP_SUMMARY_VIEW_SQL = """
     SELECT
         ROW_NUMBER() OVER () AS id
         , "nc_stop"."agency_id"
-        , DATE_PART('year', DATE_TRUNC('year', date AT TIME ZONE 'America/New_York'))::integer AS "year"
-        , "nc_stop"."date"
+        , DATE_TRUNC('month', date AT TIME ZONE 'America/New_York') AS "date"
         , "nc_stop"."purpose" AS "stop_purpose"
         , "nc_stop"."engage_force"
         , "nc_search"."type" AS "search_type"
@@ -189,8 +188,8 @@ STOP_SUMMARY_VIEW_SQL = """
     LEFT OUTER JOIN "nc_contraband"
         ON ("nc_stop"."stop_id" = "nc_contraband"."stop_id")
     GROUP BY
-        2, 3, 4, 5, 6, 7, 8, 9, 10, 11
-    ORDER BY "agency_id", "year" ASC;
+        2, 3, 4, 5, 6, 7, 8, 9, 10
+    ORDER BY "agency_id", "date" ASC;
 """  # noqa
 
 
@@ -202,7 +201,6 @@ class StopSummary(pg.ReadOnlyMaterializedView):
     with_data = False
 
     id = models.PositiveIntegerField(primary_key=True)
-    year = models.IntegerField()
     date = models.DateTimeField()
     agency = models.ForeignKey("Agency", on_delete=models.DO_NOTHING)
     stop_purpose = models.PositiveSmallIntegerField(choices=PURPOSE_CHOICES)

--- a/nc/models.py
+++ b/nc/models.py
@@ -168,7 +168,7 @@ STOP_SUMMARY_VIEW_SQL = """
     SELECT
         ROW_NUMBER() OVER () AS id
         , "nc_stop"."agency_id"
-        , DATE_TRUNC('month', date AT TIME ZONE 'America/New_York') AS "date"
+        , DATE_TRUNC('month', date AT TIME ZONE 'America/New_York')::date AS "date"
         , "nc_stop"."purpose" AS "stop_purpose"
         , "nc_stop"."engage_force"
         , "nc_search"."type" AS "search_type"
@@ -201,7 +201,7 @@ class StopSummary(pg.ReadOnlyMaterializedView):
     with_data = False
 
     id = models.PositiveIntegerField(primary_key=True)
-    date = models.DateTimeField()
+    date = models.DateField()
     agency = models.ForeignKey("Agency", on_delete=models.DO_NOTHING)
     stop_purpose = models.PositiveSmallIntegerField(choices=PURPOSE_CHOICES)
     engage_force = models.BooleanField()
@@ -216,6 +216,7 @@ class StopSummary(pg.ReadOnlyMaterializedView):
         managed = False
         indexes = [
             models.Index(fields=["agency", "officer_id", "search_type"]),
+            models.Index(fields=["agency", "date"]),
             models.Index(fields=["engage_force"]),
             models.Index(fields=["contraband_found"]),
         ]

--- a/nc/views.py
+++ b/nc/views.py
@@ -126,7 +126,8 @@ class AgencyViewSet(viewsets.ReadOnlyModelViewSet):
             group_by_tuple = tuple(gp_list)
 
         qs = qs.values(*group_by_tuple)
-        qs = qs.annotate(count=Sum("count")).order_by("date")
+        order_by = "date" if date_precision == "month" else "year"
+        qs = qs.annotate(count=Sum("count")).order_by(order_by)
         for stop in qs:
             data = {}
             if "year" in group_by_tuple:
@@ -159,7 +160,7 @@ class AgencyViewSet(viewsets.ReadOnlyModelViewSet):
             results.add(**data)
 
     @action(detail=True, methods=["get"])
-    # @cache_response(key_func=query_cache_key_func)
+    @cache_response(key_func=query_cache_key_func)
     def stops(self, request, pk=None):
         results = GroupedData(by="year", defaults=GROUP_DEFAULTS)
         self.query(results, group_by=("year", "driver_race", "driver_ethnicity"))


### PR DESCRIPTION
Suggested enhancements to #187:

* Reduced size of materialized view by ~13.5m rows
* Add multicolumn index on ("agency", "date") to optimize date filtering with Parallel Index Scans

### Local testing

```sh
./migrate_all_dbs.sh
python manage.py refresh_pgviews --database=traffic_stops_nc
```

### Analysis

Before:

```sql
traffic_stops_nc=# SELECT count(*) FROM nc_stopsummary;
  count   
----------
 22864268
(1 row)
```

After:

```sql
traffic_stops_nc=# SELECT count(*) FROM nc_stopsummary;
  count  
---------
 9429402
(1 row)
```

Savings:

```sql
\pset numericlocale
traffic_stops_nc=# SELECT 22864268-9429402 AS removed_rows;
 removed_rows 
--------------
   13,434,866
```

Add multicolumn index on ("agency", "date") to optimize date filtering with Parallel Index Scans:

```sql
traffic_stops_nc=# EXPLAIN ANALYZE SELECT "nc_stopsummary"."driver_race",
       "nc_stopsummary"."driver_ethnicity",
       EXTRACT('year' FROM "nc_stopsummary"."date") AS "year",
       SUM("nc_stopsummary"."count") AS "count"
  FROM "nc_stopsummary"
 WHERE ("nc_stopsummary"."agency_id" = 52 AND "nc_stopsummary"."date" BETWEEN '2014-05-01'::date AND '2023-04-01'::date)
 GROUP BY "nc_stopsummary"."driver_race",
       "nc_stopsummary"."driver_ethnicity",
       EXTRACT('year' FROM "nc_stopsummary"."date")
 ORDER BY "year" ASC;
                                                                                          QUERY PLAN                                                                                           
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Finalize GroupAggregate  (cost=52540.57..53278.53 rows=2750 width=20) (actual time=53.687..55.798 rows=90 loops=1)
   Group Key: (date_part('year'::text, (date)::timestamp without time zone)), driver_race, driver_ethnicity
   ->  Gather Merge  (cost=52540.57..53182.28 rows=5500 width=20) (actual time=53.682..55.756 rows=262 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Sort  (cost=51540.54..51547.42 rows=2750 width=20) (actual time=46.402..46.406 rows=87 loops=3)
               Sort Key: (date_part('year'::text, (date)::timestamp without time zone)), driver_race, driver_ethnicity
               Sort Method: quicksort  Memory: 31kB
               Worker 0:  Sort Method: quicksort  Memory: 31kB
               Worker 1:  Sort Method: quicksort  Memory: 31kB
               ->  Partial HashAggregate  (cost=51342.19..51383.44 rows=2750 width=20) (actual time=46.282..46.304 rows=87 loops=3)
                     Group Key: date_part('year'::text, (date)::timestamp without time zone), driver_race, driver_ethnicity
                     ->  Parallel Index Scan using nc_stopsumm_agency__a8616e_idx on nc_stopsummary  (cost=0.43..50038.11 rows=130408 width=16) (actual time=0.131..30.129 rows=97752 loops=3)
                           Index Cond: ((agency_id = 52) AND (date >= '2014-05-01'::date) AND (date <= '2023-04-01'::date))
 Planning Time: 0.382 ms
 Execution Time: 56.028 ms
(16 rows)
```

