### PR TITLE
Add popper-js for tooltips

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@loadable/component": "^5.15.2",
+        "@popperjs/core": "^2.11.7",
         "@sentry/react": "^7.6.0",
         "autosuggest-highlight": "^3.3.0",
         "axios": "^0.27.2",
@@ -25,6 +26,7 @@
         "react-dom": "^18.2.0",
         "react-helmet": "^6.1.0",
         "react-loadable": "^5.5.0",
+        "react-popper": "^2.3.0",
         "react-router-dom": "^5.3.3",
         "react-scripts": "5.0.1",
         "react-table": "^7.8.0",
@@ -2963,9 +2965,9 @@
       }
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.5",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
-      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "proxy": "http://localhost:8000/",
   "dependencies": {
     "@loadable/component": "^5.15.2",
+    "@popperjs/core": "^2.11.7",
     "@sentry/react": "^7.6.0",
     "autosuggest-highlight": "^3.3.0",
     "axios": "^0.27.2",
@@ -21,6 +22,7 @@
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
     "react-loadable": "^5.5.0",
+    "react-popper": "^2.3.0",
     "react-router-dom": "^5.3.3",
     "react-scripts": "5.0.1",
     "react-table": "^7.8.0",

--- a/frontend/src/Components/AboutPage/AboutPage.js
+++ b/frontend/src/Components/AboutPage/AboutPage.js
@@ -94,7 +94,9 @@ function AboutPage() {
             datasets are incomplete or remain unreported. Where data sets are incomplete or missing
             from the website it is because they have not been reported to the NC SBI. NC CopWatch
             does not have access to, nor does it publish, the names of officers, drivers, or
-            passengers involved in traffic stops.
+            passengers involved in traffic stops. The census data on NC CopWatch is taken directly
+            from the US Census Bureau’s “ACS 5-Year Estimates Detailed Tables” for the most recent
+            year available.
           </S.AboutPageParagraph>
           <S.AboutPageParagraph>
             NC CopWatch is a project of{' '}

--- a/frontend/src/Components/AgencyData/AgencyHeader.js
+++ b/frontend/src/Components/AgencyData/AgencyHeader.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTheme } from 'styled-components';
 import { AnimatePresence } from 'framer-motion';
 import * as S from './AgencyHeader.styled';
 import { P, SIZES, WEIGHTS, COLORS } from '../../styles/StyledComponents/Typography';
+import { usePopper } from 'react-popper';
 
 // Routing
 import { useHistory, useParams } from 'react-router-dom';
@@ -15,7 +16,7 @@ import { calculatePercentage, RACES } from '../Charts/chartUtils';
 import toTitleCase from '../../util/toTitleCase';
 
 import { ICONS } from '../../img/icons/Icon';
-import { AGENCY_LIST_SLUG } from '../../Routes/slugs';
+import { ABOUT_SLUG, AGENCY_LIST_SLUG } from '../../Routes/slugs';
 import BackButton from '../Elements/BackButton';
 import Button from '../Elements/Button';
 import * as ChartHeaderStyles from '../Charts/ChartSections/ChartHeader.styled';
@@ -44,6 +45,28 @@ function AgencyHeader({
       return `last reported stop from department`;
     }
     return '';
+  };
+
+  const [referenceElement, setReferenceElement] = useState(null);
+  const [popperElement, setPopperElement] = useState(null);
+  const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    placement: 'top',
+    modifiers: [
+      {
+        name: 'offset',
+        options: {
+          offset: [showCompareDepartments ? 0 : -300, 10],
+        },
+      },
+    ],
+  });
+
+  const showTooltip = () => {
+    popperElement.setAttribute('data-show', true);
+  };
+
+  const hideTooltip = () => {
+    popperElement.removeAttribute('data-show');
   };
 
   return (
@@ -88,8 +111,18 @@ function AgencyHeader({
                 </S.ReportedDate>
               </P>
             </S.EntityDetails>
+            <S.Tooltip ref={setPopperElement} style={styles.popper} {...attributes.popper}>
+              Sourced from U.S. Year Census, For more info go to the about page
+            </S.Tooltip>
             <S.CensusDemographics>
-              <S.CensusTitle>CENSUS DEMOGRAPHICS</S.CensusTitle>
+              <S.CensusTitle
+                onMouseEnter={showTooltip}
+                onMouseLeave={hideTooltip}
+                ref={setReferenceElement}
+                onClick={() => history.push(ABOUT_SLUG)}
+              >
+                CENSUS DEMOGRAPHICS
+              </S.CensusTitle>
               <S.CensusRow>
                 {Object.keys(agencyDetails.census_profile).length > 0 ? (
                   RACES.map((race) => {

--- a/frontend/src/Components/AgencyData/AgencyHeader.js
+++ b/frontend/src/Components/AgencyData/AgencyHeader.js
@@ -112,7 +112,7 @@ function AgencyHeader({
               </P>
             </S.EntityDetails>
             <S.Tooltip ref={setPopperElement} style={styles.popper} {...attributes.popper}>
-              Sourced from U.S. Year Census, For more info go to the about page
+              Sourced from U.S. Census Bureau. See About page for more info.
             </S.Tooltip>
             <S.CensusDemographics>
               <S.CensusTitle

--- a/frontend/src/Components/AgencyData/AgencyHeader.styled.js
+++ b/frontend/src/Components/AgencyData/AgencyHeader.styled.js
@@ -136,3 +136,17 @@ export const ShowDepartmentsButton = styled.div`
   display: block;
   margin: 10px 0;
 `;
+
+export const Tooltip = styled.div`
+  background: #333;
+  color: white;
+  font-weight: bold;
+  padding: 4px 8px;
+  font-size: 13px;
+  border-radius: 4px;
+  visibility: hidden;
+
+  &[data-show='true'] {
+    visibility: visible;
+  }
+`;


### PR DESCRIPTION
Ticket:
- https://app.clickup.com/t/863gean72

## Changes
- Adds `popper-js` package for tooltips (using in later tickets as well)
- Update about page to include source of census

## Preview:
![Screen Shot 2023-04-12 at 2 07 10 PM](https://user-images.githubusercontent.com/26633909/231558968-3e5f5dc1-96fc-42b5-8e3a-f84cfdaa6cae.png)
![Screen Shot 2023-04-12 at 3 01 39 PM](https://user-images.githubusercontent.com/26633909/231558986-90f2c4e2-e5bc-4479-b39f-8214699d5418.png)
