### PR TITLE
Add from/to to list of cache params

### DIFF
--- a/nc/views.py
+++ b/nc/views.py
@@ -67,7 +67,7 @@ SEARCH_TYPE_CHOICES = dict(SEARCH_TYPE_CHOICES_TUPLES)
 
 
 class QueryKeyConstructor(DefaultObjectKeyConstructor):
-    params_query = bits.QueryParamsKeyBit(["officer"])
+    params_query = bits.QueryParamsKeyBit(["officer", "from", "to"])
 
 
 query_cache_key_func = QueryKeyConstructor()


### PR DESCRIPTION
- Update `QueryKeyConstructor` to include `from` and `to` params to update cached responses.