### PR TITLE
Add tooltips to the data labels for Search Rate graph

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,9 @@ dl-db-dump:
 	export AWS_PROFILE=copwatch
 	inv aws.configure-eks-kubeconfig
 	inv staging pod.get-db-dump --db-var=DATABASE_URL_NC
+
+refresh-view:
+	@echo 'Migrating all databases'
+	./migrate_all_dbs.sh
+	@echo 'Refreshing the StopSummary materialized view'
+	python manage.py refresh_pgviews --database=traffic_stops_nc

--- a/frontend/src/Components/Charts/SearchRate/SearchRate.js
+++ b/frontend/src/Components/Charts/SearchRate/SearchRate.js
@@ -211,7 +211,6 @@ function SearchRate(props) {
                 >
                   {tooltipText}
                 </Tooltip>
-                )
                 <GroupedBar
                   data={chartData}
                   loading={chartState.loading[LIKELIHOOD_OF_SEARCH]}
@@ -221,7 +220,13 @@ function SearchRate(props) {
                       <VictoryLabel
                         x={100}
                         dx={-50}
-                        style={{ fontSize: 6 }}
+                        style={{
+                          fontSize: 6,
+                          cursor: 'default',
+                          textDecorationLine: 'underline',
+                          textDecorationStyle: 'dotted',
+                          textUnderlineOffset: '5px',
+                        }}
                         id={(t) => (Array.isArray(t.text) ? t.text.join('') : null)}
                         events={{
                           onMouseEnter: (evt) => showTooltip(evt),

--- a/frontend/src/Components/Charts/SearchRate/SearchRate.js
+++ b/frontend/src/Components/Charts/SearchRate/SearchRate.js
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import SearchRateStyled from './SearchRate.styled';
+import SearchRateStyled, { Tooltip } from './SearchRate.styled';
 import * as S from '../ChartSections/ChartsCommon.styled';
 import { useTheme } from 'styled-components';
+import { usePopper } from 'react-popper';
 
 // Router
 import { useHistory } from 'react-router-dom';
@@ -32,6 +33,7 @@ import Legend from '../ChartSections/Legend/Legend';
 import DataSubsetPicker from '../ChartSections/DataSubsetPicker/DataSubsetPicker';
 import GroupedBar from '../ChartPrimitives/GroupedBar';
 import { VictoryLabel } from 'victory';
+import { tooltipLanguage } from '../../../util/tooltipLanguage';
 
 function SearchRate(props) {
   const { agencyId, showCompare } = props;
@@ -51,6 +53,32 @@ function SearchRate(props) {
 
   const renderMetaTags = useMetaTags();
   const [renderTableModal, { openModal }] = useTableModal();
+
+  const [referenceElement, setReferenceElement] = useState(null);
+  const [tooltipText, setTooltipText] = useState('');
+  const [popperElement, setPopperElement] = useState(null);
+  const { styles, attributes } = usePopper(referenceElement, popperElement, {
+    placement: 'top',
+    modifiers: [
+      {
+        name: 'offset',
+        options: {
+          offset: [0, 10],
+        },
+      },
+    ],
+  });
+
+  const showTooltip = (e) => {
+    setReferenceElement(e.currentTarget);
+    setTooltipText(tooltipLanguage(e.target.parentElement.id));
+    popperElement.setAttribute('data-show', true);
+  };
+
+  const hideTooltip = () => {
+    setTooltipText('');
+    popperElement.removeAttribute('data-show');
+  };
 
   /* BUILD DATA */
   useEffect(() => {
@@ -170,24 +198,50 @@ function SearchRate(props) {
                 </P>
               </S.NoBaseSearches>
             ) : (
-              <GroupedBar
-                data={chartData}
-                loading={chartState.loading[LIKELIHOOD_OF_SEARCH]}
-                horizontal
-                iAxisProps={{
-                  tickLabelComponent: <VictoryLabel x={100} dx={-50} style={{ fontSize: 6 }} />,
-                  tickFormat: (t) => (t.split ? t.split(' ') : t),
-                }}
-                dAxisProps={{
-                  tickFormat: (t) => `${t}%`,
-                }}
-                chartProps={{
-                  height: 500,
-                  width: 400,
-                }}
-                barProps={{ barWidth: 10, yAxisLabel: (val) => `${val}%` }}
-                toolTipFontSize={7}
-              />
+              <>
+                <Tooltip
+                  ref={setPopperElement}
+                  style={{
+                    ...styles.popper,
+                    maxWidth: '500px',
+                    zIndex: 1000,
+                    display: tooltipText !== '' ? 'block' : 'none',
+                  }}
+                  {...attributes.popper}
+                >
+                  {tooltipText}
+                </Tooltip>
+                )
+                <GroupedBar
+                  data={chartData}
+                  loading={chartState.loading[LIKELIHOOD_OF_SEARCH]}
+                  horizontal
+                  iAxisProps={{
+                    tickLabelComponent: (
+                      <VictoryLabel
+                        x={100}
+                        dx={-50}
+                        style={{ fontSize: 6 }}
+                        id={(t) => (Array.isArray(t.text) ? t.text.join('') : null)}
+                        events={{
+                          onMouseEnter: (evt) => showTooltip(evt),
+                          onMouseLeave: () => hideTooltip(),
+                        }}
+                      />
+                    ),
+                    tickFormat: (t) => (t.split ? t.split(' ') : t),
+                  }}
+                  dAxisProps={{
+                    tickFormat: (t) => `${t}%`,
+                  }}
+                  chartProps={{
+                    height: 500,
+                    width: 400,
+                  }}
+                  barProps={{ barWidth: 10, yAxisLabel: (val) => `${val}%` }}
+                  toolTipFontSize={7}
+                />
+              </>
             )}
           </S.LineWrapper>
           <S.LegendBelow>

--- a/frontend/src/Components/Charts/SearchRate/SearchRate.styled.js
+++ b/frontend/src/Components/Charts/SearchRate/SearchRate.styled.js
@@ -2,3 +2,17 @@ import styled from 'styled-components';
 import ChartPageBase from '../ChartSections/ChartPageBase';
 
 export default styled(ChartPageBase)``;
+
+export const Tooltip = styled.div`
+  background: #333;
+  color: white;
+  font-weight: bold;
+  padding: 4px 8px;
+  font-size: 13px;
+  border-radius: 4px;
+  visibility: hidden;
+
+  &[data-show='true'] {
+    visibility: visible;
+  }
+`;

--- a/frontend/src/util/tooltipLanguage.js
+++ b/frontend/src/util/tooltipLanguage.js
@@ -1,6 +1,6 @@
 export const tooltipLanguage = (stopCause) =>
   ({
-    Average: 'REPLACE ME',
+    Average: '',
     Checkpoint:
       'A checkpoint can be a barrier, or a manned entrance, where drivers are subjected to a security check, often by law enforcement. For example, a checkpoint could be where police set up roadblocks so they can stop and inspect all (or almost all) drivers and vehicles that pass through.',
     OtherMotorVehicleViolation:

--- a/frontend/src/util/tooltipLanguage.js
+++ b/frontend/src/util/tooltipLanguage.js
@@ -1,0 +1,24 @@
+export const tooltipLanguage = (stopCause) =>
+  ({
+    Average: 'REPLACE ME',
+    Checkpoint:
+      'A checkpoint can be a barrier, or a manned entrance, where drivers are subjected to a security check, often by law enforcement. For example, a checkpoint could be where police set up roadblocks so they can stop and inspect all (or almost all) drivers and vehicles that pass through.',
+    OtherMotorVehicleViolation:
+      'If the stop falls within this category, the officer may have stopped an individual for some other violation not listed within the above/below categories',
+    Investigation:
+      'An investigation is a systematic, thorough attempt to learn the facts about a potential case/crime. An investigation is the process in which law enforcement may go about gathering more information about the case in question. For example, a car may be stopped during an investigation if the police are looking for a suspect to a crime, and the car matches the description of the suspect in question.',
+    SeatBeltViolation:
+      'Under NC law, each occupant of a vehicle is required to be fastened by a seat belt when it is in motion. A seatbelt violation is when one or more occupant of a vehicle is not properly wearing a seatbelt while the vehicle is in motion.',
+    VehicleRegulatoryViolation:
+      'A vehicle equipment violation is considered a non-moving violation, and often refers to faulty equipment in a vehicle. Improper equipment may describe a vehicle having equipment or mechanical problems such as dangerous tires, improper muffler, or a broken speedometer. Some other common vehicle equipment violations people might be stopped for are broken/inoperable lights, tinted windows that are too dark, cracked windshield wipers.',
+    VehicleEquipmentViolation:
+      'A vehicle equipment violation is considered a non-moving violation, and often refers to faulty equipment in a vehicle. Improper equipment may describe a vehicle having equipment or mechanical problems such as dangerous tires, improper muffler, or a broken speedometer. Some other common vehicle equipment violations people might be stopped for are broken/inoperable lights, tinted windows that are too dark, cracked windshield wipers.',
+    SafeMovementViolation:
+      'A safe movement violation in North Carolina is a violation of safe movement practices while driving. This can apply to many unsafe driving practices, such as unsafe lane changes or improper turns.',
+    DrivingWhileImpaired:
+      'If someone is stopped for suspicion of driving while impaired, the officer may claim to have reason to believe that the person is operating the car while under the influence of any impairing substance, such as alcohol or drugs.',
+    'StopLight/SignViolation':
+      'Someone may be stopped for this kind of violation, for example, by failing to stop completely at a stop sign, by running a red light, or by disregarding a particular road sign.',
+    SpeedLimitViolation:
+      'A speed limit violation is when an individual is stopped for driving faster than the posted speed limit in a given area, and on a given road. Someone may be stopped for this kind of violation if an officer suspects them of driving over the posted speed limit, or too fast for the current road conditions.',
+  }[stopCause]);


### PR DESCRIPTION
Ticket:
- https://app.clickup.com/t/863gea6f1

Changes:
- Add a util function to return correct copy for each stop purpose
- Add a popperjs tooltip to render above each stop purpose when hovering
- Add convenient make command to refresh stop summary 

Preview:
![Screen Shot 2023-05-02 at 5 55 20 PM](https://user-images.githubusercontent.com/26633909/235794773-1b99b403-e000-4591-85bc-58e75854507d.png)
