### PR TITLE
Add resource created date as readonly field in resource detail page

### DIFF
--- a/nc/admin.py
+++ b/nc/admin.py
@@ -54,7 +54,15 @@ class InlineResourceFile(admin.StackedInline):
 
 
 class ResourceAdmin(admin.ModelAdmin):
-    fields = ("agencies", "title", "description", "publication_date", "image", "view_more_link")
+    fields = (
+        "agencies",
+        "title",
+        "description",
+        "publication_date",
+        "created_date",
+        "image",
+        "view_more_link",
+    )
     list_display = (
         "title",
         "created_date",
@@ -62,6 +70,7 @@ class ResourceAdmin(admin.ModelAdmin):
     )
     filter_horizontal = ("agencies",)
     inlines = [InlineResourceFile]
+    readonly_fields = ("created_date",)
 
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)


### PR DESCRIPTION
Ticket:
- https://app.clickup.com/t/863g8xz5j 

Changes:
- Adds `created_date` to resource detail page

Preview:
![Screen Shot 2023-05-08 at 2 11 40 PM](https://user-images.githubusercontent.com/26633909/236899323-b66a9016-53da-473e-a176-0495a456ef11.png)
