### PR TITLE
Kubernetes upgrades to v1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,8 +113,8 @@ RUN groupadd --gid $USER_GID $USERNAME \
 #   openssh-client -- for git over SSH
 #   sudo -- to run commands as superuser
 #   vim -- enhanced vi editor for commits
-ENV KUBE_CLIENT_VERSION="v1.22.15"
-ENV HELM_VERSION="3.8.2"
+ENV KUBE_CLIENT_VERSION="v1.25.10"
+ENV HELM_VERSION="3.12.0"
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     --mount=type=cache,mode=0755,target=/root/.cache/pip \
     set -ex \

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,6 +124,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
     docker-compose-plugin \
     git-core \
     gnupg2 \
+    jq \
     libpcre3 \
     libpq-dev \
     mime-support \

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -64,7 +64,7 @@ k8s_install_descheduler: yes
 # You must set the k8s_descheduler_chart_version to match the Kubernetes
 # node version (0.23.x -> K8s 1.23.x); see:
 # https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
-k8s_descheduler_chart_version: v0.22.1
+k8s_descheduler_chart_version: v0.24.1
 # See values.yaml for options:
 # https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
 k8s_descheduler_release_values:

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -96,7 +96,7 @@ k8s_iam_users: [copelco]
 # https://github.com/kubernetes/ingress-nginx/releases
 k8s_ingress_nginx_chart_version: "4.4.2"
 # https://github.com/jetstack/cert-manager/releases
-k8s_cert_manager_chart_version: "v1.7.2"
+k8s_cert_manager_chart_version: "v1.11.1"
 # AWS only:
 # Use the newer load balancer type (NLB). DO NOT edit k8s_aws_load_balancer_type after
 # creating your Service.

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -64,7 +64,7 @@ k8s_install_descheduler: yes
 # You must set the k8s_descheduler_chart_version to match the Kubernetes
 # node version (0.23.x -> K8s 1.23.x); see:
 # https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
-k8s_descheduler_chart_version: v0.24.1
+k8s_descheduler_chart_version: v0.25.2
 # See values.yaml for options:
 # https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
 k8s_descheduler_release_values:

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -2,7 +2,7 @@
 
 - src: https://github.com/caktus/ansible-role-django-k8s
   name: caktus.django-k8s
-  version: v1.5.1
+  version: v1.6.0
 
 - src: https://github.com/caktus/ansible-role-aws-web-stacks
   name: caktus.aws-web-stacks
@@ -10,8 +10,8 @@
 
 - src: https://github.com/caktus/ansible-role-k8s-web-cluster
   name: caktus.k8s-web-cluster
-  version: v1.4.0
+  version: v1.5.0
 
 - src: https://github.com/caktus/ansible-role-k8s-hosting-services
   name: caktus.k8s-hosting-services
-  version: v0.9.0
+  version: v0.11.0

--- a/requirements/base/base.in
+++ b/requirements/base/base.in
@@ -5,7 +5,7 @@ census==0.8.19
 us
 dealer
 boto
-boto3==1.26.109
+boto3==1.26.87
 botocore==1.29.109
 click==8.1.3
 django-cache-machine==1.2.0

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -12,7 +12,7 @@ billiard==3.6.3.0
     # via celery
 boto==2.49.0
     # via -r requirements/base/base.in
-boto3==1.26.109
+boto3==1.26.87
     # via -r requirements/base/base.in
 botocore==1.29.109
     # via

--- a/requirements/deploy/deploy.in
+++ b/requirements/deploy/deploy.in
@@ -1,6 +1,6 @@
 # Deploy.in
 -c ../base/base.txt
 python3-memcached
-newrelic==8.7.0
-sentry-sdk==1.16.0
+newrelic==8.8.0
+sentry-sdk==1.24.0
 uwsgi

--- a/requirements/deploy/deploy.txt
+++ b/requirements/deploy/deploy.txt
@@ -8,11 +8,11 @@ certifi==2020.6.20
     # via
     #   -c requirements/deploy/../base/base.txt
     #   sentry-sdk
-newrelic==8.7.0
+newrelic==8.8.0
     # via -r requirements/deploy/deploy.in
 python3-memcached==1.51
     # via -r requirements/deploy/deploy.in
-sentry-sdk==1.16.0
+sentry-sdk==1.24.0
     # via -r requirements/deploy/deploy.in
 urllib3==1.26.14
     # via

--- a/requirements/dev/dev.in
+++ b/requirements/dev/dev.in
@@ -12,7 +12,7 @@ cffi==1.15.0
 Jinja2==3.0.3
 openshift==0.12
 kubernetes==12.0.0
-kubernetes-validate
+kubernetes-validate~=1.25.0
 
 troposphere
 

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -30,7 +30,7 @@ babel==2.8.0
     # via sphinx
 backcall==0.1.0
     # via ipython
-boto3==1.26.109
+boto3==1.26.87
     # via
     #   -c requirements/dev/../base/base.txt
     #   invoke-kubesae
@@ -120,7 +120,7 @@ kubernetes==12.0.0
     # via
     #   -r requirements/dev/dev.in
     #   openshift
-kubernetes-validate==1.18.0
+kubernetes-validate==1.25.2
     # via -r requirements/dev/dev.in
 livereload==2.6.2
     # via sphinx-autobuild


### PR DESCRIPTION
Closes:
- https://app.clickup.com/t/86774uj0w

### Summary

Performs Kubernetes upgrades in the traffic stops cluster. Updates the following:

Kubernetes and Nodes -> `1.25`
Kubectl -> `1.25.10`
Helm -> `3.12.0`
Descheduler -> `0.25`
Ansible requirements
Other minor package dependencies