### PR TITLE
Add pie charts for grouped by stop purpose

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "react-popper": "^2.3.0",
         "react-router-dom": "^5.3.3",
         "react-scripts": "5.0.1",
+        "react-switch": "^7.0.0",
         "react-table": "^7.8.0",
         "react-tooltip": "^4.2.21",
         "reaktus": "^0.1.20",
@@ -14129,6 +14130,18 @@
       "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
       "peerDependencies": {
         "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-switch": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-switch/-/react-switch-7.0.0.tgz",
+      "integrity": "sha512-KkDeW+cozZXI6knDPyUt3KBN1rmhoVYgAdCJqAh7st7tk8YE6N0iR89zjCWO8T8dUTeJGTR0KU+5CHCRMRffiA==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-table": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "react-popper": "^2.3.0",
     "react-router-dom": "^5.3.3",
     "react-scripts": "5.0.1",
+    "react-switch": "^7.0.0",
     "react-table": "^7.8.0",
     "react-tooltip": "^4.2.21",
     "reaktus": "^0.1.20",

--- a/frontend/src/Components/App.js
+++ b/frontend/src/Components/App.js
@@ -43,6 +43,7 @@ import * as S from './HomePage/HomePage.styled';
 
 // New Charts
 import {
+  ArcElement,
   CategoryScale,
   Chart as ChartJS,
   Legend,
@@ -53,7 +54,16 @@ import {
   Tooltip,
 } from 'chart.js';
 
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
+ChartJS.register(
+  ArcElement,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
 
 function App() {
   const [showCompare, setShowCompare] = React.useState(false);

--- a/frontend/src/Components/Charts/ChartSections/ChartsCommon.styled.js
+++ b/frontend/src/Components/Charts/ChartSections/ChartsCommon.styled.js
@@ -3,6 +3,7 @@ import { smallerThanDesktop, smallerThanTabletLandscape } from '../../../styles/
 import { H2 } from '../../../styles/StyledComponents/Typography';
 
 export const ChartSection = styled.div`
+  margin-top: ${(props) => (props.marginTop ? props.marginTop : '3')}em;
   margin-bottom: 2em;
 `;
 

--- a/frontend/src/Components/Charts/ChartSections/Legend/Legend.styled.js
+++ b/frontend/src/Components/Charts/ChartSections/Legend/Legend.styled.js
@@ -51,7 +51,6 @@ export const KeyLabel = styled.p`
 `;
 
 export const Addendum = styled.p`
-  margin-top: 1em;
   font-style: italic;
   color: ${(props) => props.theme.colors.textLight};
   font-size: 16px;

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -27,7 +27,7 @@ import {
 import useDataset, { STOPS_BY_REASON, STOPS, AGENCY_DETAILS } from '../../../Hooks/useDataset';
 
 // Elements
-import { P } from '../../../styles/StyledComponents/Typography';
+import { P, WEIGHTS } from '../../../styles/StyledComponents/Typography';
 
 // Hooks
 import useMetaTags from '../../../Hooks/useMetaTags';
@@ -152,16 +152,19 @@ function TrafficStops(props) {
   const [visibleStopsGroupedByPurpose, setVisibleStopsGroupedByPurpose] = useState([
     {
       key: 'safety',
+      title: 'Safety Violation',
       visible: true,
       order: 1,
     },
     {
       key: 'regulatory',
+      title: 'Regulatory/Equipment',
       visible: true,
       order: 2,
     },
     {
       key: 'other',
+      title: 'Other',
       visible: false,
       order: 3,
     },
@@ -554,7 +557,10 @@ function TrafficStops(props) {
     const otherGraphs = toggleState.filter((v) => v.key !== key);
 
     setVisibleStopsGroupedByPurpose(
-      [...otherGraphs, { key, visible: !toggleGraph.visible, order: toggleGraph.order }].sort(
+      [
+        ...otherGraphs,
+        { key, visible: !toggleGraph.visible, title: toggleGraph.title, order: toggleGraph.order },
+      ].sort(
         // eslint-disable-next-line no-nested-ternary
         (a, b) => (a.order < b.order ? (a.order === b.order ? 0 : -1) : 1)
       )
@@ -660,7 +666,7 @@ function TrafficStops(props) {
           </S.LegendBeside>
         </S.ChartSubsection>
       </S.ChartSection>
-      <S.ChartSection>
+      <S.ChartSection marginTop={5}>
         <ChartHeader
           chartTitle="Traffic Stops By Stop Purpose"
           handleViewData={showStopPurposeModal}
@@ -688,19 +694,13 @@ function TrafficStops(props) {
           </StopGroupsContainer>
         </LineWrapper>
       </S.ChartSection>
-      <S.ChartSection>
+      <S.ChartSection marginTop={5}>
         <ChartHeader
           chartTitle="Traffic Stops By Stop Purpose and Race Count"
           handleViewData={showGroupedStopPurposeModal}
         />
         <P>Shows the number of traffics stops broken down by purpose and race / ethnicity.</P>
-        <Legend
-          heading="Show on graph:"
-          keys={stopPurposeEthnicGroups}
-          onKeySelect={handleStopPurposeKeySelected}
-          showNonHispanic
-          row
-        />
+
         <NewModal
           tableHeader="Traffic Stops By Stop Purpose and Race Count"
           tableSubheader="Shows the number of traffics stops broken down by purpose and race / ethnicity"
@@ -728,23 +728,12 @@ function TrafficStops(props) {
             gap: '10px',
             marginTop: '10px',
             marginBottom: '10px',
+            alignItems: 'center',
           }}
         >
           <span>Switch to {checked ? 'line' : 'pie'} charts</span>
           <Switch onChange={handleChange} checked={checked} className="react-switch" />
         </div>
-        <div style={{ display: 'flex', gap: '10px', flexDirection: 'row' }}>
-          {visibleStopsGroupedByPurpose.map((vg, i) => (
-            <Checkbox
-              label={`Toggle ${vg.key}`}
-              value={vg.key}
-              key={i}
-              checked={vg.visible}
-              onChange={toggleGroupedPurposeGraphs}
-            />
-          ))}
-        </div>
-
         <LineWrapper visible={checked === false}>
           <GroupedStopsContainer visible={visibleStopsGroupedByPurpose[0].visible}>
             <LineChart
@@ -812,6 +801,31 @@ function TrafficStops(props) {
             />
           </GroupedStopsContainer>
         </PieWrapper>
+
+        <Legend
+          heading="Show on graph:"
+          keys={stopPurposeEthnicGroups}
+          onKeySelect={handleStopPurposeKeySelected}
+          showNonHispanic
+          row
+        />
+
+        <div style={{ marginTop: '2em' }}>
+          <P weight={WEIGHTS[1]}>Toggle graphs:</P>
+          <div style={{ display: 'flex', gap: '10px', flexDirection: 'row' }}>
+            {visibleStopsGroupedByPurpose.map((vg, i) => (
+              <Checkbox
+                height={25}
+                width={25}
+                label={vg.title}
+                value={vg.key}
+                key={i}
+                checked={vg.visible}
+                onChange={toggleGroupedPurposeGraphs}
+              />
+            ))}
+          </div>
+        </div>
       </S.ChartSection>
     </TrafficStopsStyled>
   );

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import TrafficStopsStyled, {
   GroupedStopsContainer,
   LineWrapper,
-  PieGroupedStopsContainer,
   PieWrapper,
   StopGroupsContainer,
 } from './TrafficStops.styled';
@@ -120,12 +119,10 @@ function TrafficStops(props) {
   };
   const groupedPieChartLabels = ['White', 'Black', 'Hispanic', 'Asian', 'Native American', 'Other'];
   const [stopsGroupedByPurposePieData, setStopsGroupedByPurposePieData] = useState({
-    labels: groupedPieChartLabels,
     safety: {
       labels: groupedPieChartLabels,
       datasets: [
         {
-          label: '% of stops',
           data: [],
           ...groupedPieChartConfig,
         },
@@ -135,7 +132,6 @@ function TrafficStops(props) {
       labels: groupedPieChartLabels,
       datasets: [
         {
-          label: '% of stops',
           data: [],
           ...groupedPieChartConfig,
         },
@@ -145,7 +141,6 @@ function TrafficStops(props) {
       labels: groupedPieChartLabels,
       datasets: [
         {
-          label: '% of stops',
           data: [],
           ...groupedPieChartConfig,
         },
@@ -194,12 +189,10 @@ function TrafficStops(props) {
         setStopsGroupedByPurpose(res.data);
 
         setStopsGroupedByPurposePieData({
-          labels: groupedPieChartLabels,
           safety: {
             labels: groupedPieChartLabels,
             datasets: [
               {
-                label: '% of stops',
                 data: buildPercentages(res.data, 'safety'),
                 ...groupedPieChartConfig,
               },
@@ -209,7 +202,6 @@ function TrafficStops(props) {
             labels: groupedPieChartLabels,
             datasets: [
               {
-                label: '% of stops',
                 data: buildPercentages(res.data, 'regulatory'),
                 ...groupedPieChartConfig,
               },
@@ -219,7 +211,6 @@ function TrafficStops(props) {
             labels: groupedPieChartLabels,
             datasets: [
               {
-                label: '% of stops',
                 data: buildPercentages(res.data, 'other'),
                 ...groupedPieChartConfig,
               },

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -4,6 +4,7 @@ import TrafficStopsStyled, {
   LineWrapper,
   PieWrapper,
   StopGroupsContainer,
+  SwitchContainer,
 } from './TrafficStops.styled';
 import * as S from '../ChartSections/ChartsCommon.styled';
 import { useTheme } from 'styled-components';
@@ -721,19 +722,10 @@ function TrafficStops(props) {
             options={groupedStopPurposeModalData.purposeTypes}
           />
         </NewModal>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'row',
-            gap: '10px',
-            marginTop: '10px',
-            marginBottom: '10px',
-            alignItems: 'center',
-          }}
-        >
+        <SwitchContainer>
           <span>Switch to {checked ? 'line' : 'pie'} charts</span>
           <Switch onChange={handleChange} checked={checked} className="react-switch" />
-        </div>
+        </SwitchContainer>
         <LineWrapper visible={checked === false}>
           <GroupedStopsContainer visible={visibleStopsGroupedByPurpose[0].visible}>
             <LineChart
@@ -812,7 +804,7 @@ function TrafficStops(props) {
 
         <div style={{ marginTop: '2em' }}>
           <P weight={WEIGHTS[1]}>Toggle graphs:</P>
-          <div style={{ display: 'flex', gap: '10px', flexDirection: 'row' }}>
+          <div style={{ display: 'flex', gap: '10px', flexDirection: 'row', flexWrap: 'wrap' }}>
             {visibleStopsGroupedByPurpose.map((vg, i) => (
               <Checkbox
                 height={25}

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.styled.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.styled.js
@@ -22,6 +22,7 @@ export const PieWrapper = styled.div`
   flex-direction: row;
   flex-wrap: wrap;
   gap: 10px;
+  justify-content: space-evenly;
 `;
 
 export const StopGroupsContainer = styled.div`
@@ -36,4 +37,13 @@ export const GroupedStopsContainer = styled.div`
     width: 100%;
   }
   display: ${(props) => (props.visible ? 'block' : 'none')};
+`;
+
+export const SwitchContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  align-items: center;
 `;

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.styled.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.styled.js
@@ -5,7 +5,7 @@ import { smallerThanDesktop, smallerThanTabletLandscape } from '../../../styles/
 export default styled(ChartPageBase)``;
 
 export const LineWrapper = styled.div`
-  display: flex;
+  display: ${(props) => (props.visible ? 'flex' : 'none')};
   flex-direction: row;
   flex-wrap: no-wrap;
   width: 85%%;
@@ -17,13 +17,20 @@ export const LineWrapper = styled.div`
   }
 `;
 
+export const PieWrapper = styled.div`
+  display: ${(props) => (props.visible ? 'flex' : 'none')};
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 10px;
+`;
+
 export const StopGroupsContainer = styled.div`
   width: 100%;
   height: 500px;
 `;
 
 export const GroupedStopsContainer = styled.div`
-  width: 33%;
+  width: 30%;
   height: 500px;
   @media (${smallerThanTabletLandscape}) {
     width: 100%;

--- a/frontend/src/Components/Elements/Dropdown/Dropdown.js
+++ b/frontend/src/Components/Elements/Dropdown/Dropdown.js
@@ -9,9 +9,9 @@ export default function Dropdown({ value, onChange, options, dropUp, dropDown })
   const containerRef = React.useRef();
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleSelect = (selection) => {
+  const handleSelect = (selection, idx) => {
     setIsOpen(false);
-    onChange(selection);
+    onChange(selection, idx);
   };
 
   // Close dropdown when anything else is clicked.
@@ -39,8 +39,8 @@ export default function Dropdown({ value, onChange, options, dropUp, dropDown })
         dropDown={dropDown}
       >
         <S.DropdownList>
-          {options?.map((option) => (
-            <S.ListItem key={option} onClick={() => handleSelect(option)}>
+          {options?.map((option, i) => (
+            <S.ListItem key={option} onClick={() => handleSelect(option, i)}>
               {option}
             </S.ListItem>
           ))}

--- a/frontend/src/Components/Elements/Inputs/Checkbox.js
+++ b/frontend/src/Components/Elements/Inputs/Checkbox.js
@@ -4,11 +4,11 @@ import * as Styled from './Checkbox.styled';
 import CheckboxIcon from '../../../img/icons/CheckboxIcon';
 import { HelpText } from './Input.styled';
 
-function Checkbox({ value, checked, onChange, label, helpText }) {
+function Checkbox({ value, checked, onChange, label, helpText, ...props }) {
   return (
     <Styled.Wrapper>
       <Styled.CheckboxWrapper onClick={() => onChange(value)}>
-        <CheckboxIcon fill="black" checked={checked} />
+        <CheckboxIcon fill="black" checked={checked} {...props} />
         {label && <Styled.Label>{label}</Styled.Label>}
       </Styled.CheckboxWrapper>
       {helpText && <HelpText>{helpText}</HelpText>}

--- a/frontend/src/Components/Elements/Inputs/Checkbox.styled.js
+++ b/frontend/src/Components/Elements/Inputs/Checkbox.styled.js
@@ -1,14 +1,18 @@
 import styled from 'styled-components';
 
-export const Wrapper = styled.div``;
+export const Wrapper = styled.div`
+  cursor: pointer;
+`;
 
 export const CheckboxWrapper = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
   margin: 0.5em 0;
+  cursor: pointer;
 `;
 
 export const Label = styled.label`
-  margin-left: 1em;
+  margin-left: 0.5em;
+  cursor: pointer;
 `;

--- a/frontend/src/Components/NewCharts/PieChart.js
+++ b/frontend/src/Components/NewCharts/PieChart.js
@@ -23,6 +23,11 @@ export default function PieChart({
       tooltip: {
         mode: 'nearest',
         intersect: false,
+        callbacks: {
+          label(context) {
+            return `${context.parsed}%`;
+          },
+        },
       },
       title: {
         display: displayTitle,

--- a/frontend/src/Components/NewCharts/PieChart.js
+++ b/frontend/src/Components/NewCharts/PieChart.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Pie } from 'react-chartjs-2';
+
+export default function PieChart({
+  data,
+  title,
+  maintainAspectRatio = true,
+  displayTitle = true,
+  displayLegend = true,
+}) {
+  const options = {
+    responsive: true,
+    maintainAspectRatio,
+    hover: {
+      mode: 'nearest',
+      intersect: false,
+    },
+    plugins: {
+      legend: {
+        display: displayLegend,
+        position: 'top',
+      },
+      tooltip: {
+        mode: 'nearest',
+        intersect: false,
+      },
+      title: {
+        display: displayTitle,
+        text: title,
+      },
+    },
+  };
+
+  return <Pie options={options} data={data} />;
+}

--- a/frontend/src/img/icons/CheckboxIcon.js
+++ b/frontend/src/img/icons/CheckboxIcon.js
@@ -5,8 +5,9 @@ import Icon, { ICONS } from './Icon';
 function CheckboxIcon({ checked, fill, ...props }) {
   return (
     <Icon
-      height="18px"
-      width="18px"
+      height={`${props.height || 18}px`}
+      width={`${props.width || 18}px`}
+      marginRight={`${props.marginRight || 0}px`}
       icon={`${checked ? ICONS.checkboxFilled : ICONS.checkboxEmpty}`}
       // fill={checked ? fill : props.theme.colors.grey}
       fill={fill}


### PR DESCRIPTION
Ticket:
- https://app.clickup.com/t/86853kxv8
- https://app.clickup.com/t/86853ndzp

What's changed:
- Adds switcher to toggle between line graphs and pie charts for the grouped by stop purpose traffic stops graph.

Preview:
![Screenshot 2023-08-02 at 11 43 36 AM](https://github.com/caktus/Traffic-Stops/assets/26633909/ba7e8f20-f453-4c63-95f8-9dfa9d3a30c7)
