### PR TITLE
Swap traffic stops by count using new charts

### DIFF
--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -214,6 +214,9 @@ function TrafficStops(props) {
     if (trafficStopsByCountPurpose !== 0) {
       params.push({ param: 'purpose', val: trafficStopsByCountPurpose });
     }
+    if (officerId !== null) {
+      params.push({ param: 'officer', val: officerId });
+    }
 
     const urlParams = params.map((p) => `${p.param}=${p.val}`).join('&');
     const url = `/api/agency/${agencyId}/stops-by-count/?${urlParams}`;
@@ -228,8 +231,12 @@ function TrafficStops(props) {
 
   // Build Stop Purpose Groups
   useEffect(() => {
+    let url = `/api/agency/${agencyId}/stop-purpose-groups/`;
+    if (officerId !== null) {
+      url = `${url}?officer=${officerId}`;
+    }
     axios
-      .get(`/api/agency/${agencyId}/stop-purpose-groups/`)
+      .get(url)
       .then((res) => {
         setStopPurposeGroups(res.data);
       })
@@ -247,8 +254,12 @@ function TrafficStops(props) {
 
   // Build Stops Grouped by Purpose
   useEffect(() => {
+    let url = `/api/agency/${agencyId}/stops-grouped-by-purpose/`;
+    if (officerId !== null) {
+      url = `${url}?officer=${officerId}`;
+    }
     axios
-      .get(`/api/agency/${agencyId}/stops-grouped-by-purpose/`)
+      .get(url)
       .then((res) => {
         setStopsGroupedByPurpose(res.data);
         updateStoppedPurposePieChart(

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -15,7 +15,6 @@ import {
   reduceFullDataset,
   calculatePercentage,
   calculateYearTotal,
-  filterSinglePurpose,
   buildStackedBarData,
   STATIC_LEGEND_KEYS,
   YEARS_DEFAULT,
@@ -35,16 +34,12 @@ import useMetaTags from '../../../Hooks/useMetaTags';
 import useTableModal from '../../../Hooks/useTableModal';
 
 // Children
-import Line from '../ChartPrimitives/Line';
 import StackedBar from '../ChartPrimitives/StackedBar';
 import Legend from '../ChartSections/Legend/Legend';
 import ChartHeader from '../ChartSections/ChartHeader';
 import DataSubsetPicker from '../ChartSections/DataSubsetPicker/DataSubsetPicker';
-import toTitleCase from '../../../util/toTitleCase';
 import useOfficerId from '../../../Hooks/useOfficerId';
 import MonthRangePicker from '../../Elements/MonthRangePicker';
-import mapDatasetKeyToEndpoint from '../../../Services/endpoints';
-import range from 'lodash.range';
 import LineChart from '../../NewCharts/LineChart';
 import axios from '../../../Services/Axios';
 import NewModal from '../../NewCharts/NewModal';
@@ -62,12 +57,8 @@ function TrafficStops(props) {
   const officerId = useOfficerId();
 
   const [stopsChartState] = useDataset(agencyId, STOPS);
-  const [reasonChartState] = useDataset(agencyId, STOPS_BY_REASON);
 
   const [pickerActive, setPickerActive] = useState(null);
-  const [pickerXAxis, setPickerXAxis] = useState(null);
-  const [forcePickerRerender, setForcePickerRerender] = useState(false);
-  const [reasonChartYearSet, setReasonChartYearSet] = useState(reasonChartState.yearSet);
 
   const [year, setYear] = useState(YEARS_DEFAULT);
 
@@ -92,9 +83,6 @@ function TrafficStops(props) {
     */
     () => STATIC_LEGEND_KEYS.map((k) => ({ ...k }))
   );
-  const [countEthnicGroups, setCountEthnicGroups] = useState(() =>
-    STATIC_LEGEND_KEYS.map((k) => ({ ...k }))
-  );
   const [stopPurposeEthnicGroups, setStopPurposeEthnicGroups] = useState(() =>
     STATIC_LEGEND_KEYS.map((k) => ({ ...k }))
   );
@@ -115,8 +103,6 @@ function TrafficStops(props) {
       },
     ],
   });
-
-  const [byCountLineData, setByCountLineData] = useState([]);
 
   const renderMetaTags = useMetaTags();
   const [renderTableModal, { openModal }] = useTableModal();
@@ -205,6 +191,41 @@ function TrafficStops(props) {
   const [showZoomedPieChart, setShowZoomedPieChart] = useState(false);
   const zoomedPieCharRef = useRef(null);
 
+  const [trafficStopsByCountRange, setTrafficStopsByCountRange] = useState(null);
+  const [trafficStopsByCountPurpose, setTrafficStopsByCountPurpose] = useState(0);
+  const [trafficStopsByCount, setTrafficStopsByCount] = useState({
+    labels: [],
+    datasets: [],
+  });
+
+  // Build Stops By Count
+  useEffect(() => {
+    const params = [];
+    if (trafficStopsByCountRange !== null) {
+      const _from = `${trafficStopsByCountRange.from.year}-${trafficStopsByCountRange.from.month
+        .toString()
+        .padStart(2, 0)}-01`;
+      const _to = `${trafficStopsByCountRange.to.year}-${trafficStopsByCountRange.to.month
+        .toString()
+        .padStart(2, 0)}-01`;
+      params.push({ param: 'from', val: _from });
+      params.push({ param: 'to', val: _to });
+    }
+    if (trafficStopsByCountPurpose !== 0) {
+      params.push({ param: 'purpose', val: trafficStopsByCountPurpose });
+    }
+
+    const urlParams = params.map((p) => `${p.param}=${p.val}`).join('&');
+    const url = `/api/agency/${agencyId}/stops-by-count/?${urlParams}`;
+
+    axios
+      .get(url)
+      .then((res) => {
+        setTrafficStopsByCount(res.data);
+      })
+      .catch((err) => console.log(err));
+  }, [trafficStopsByCountPurpose, trafficStopsByCountRange]);
+
   // Build Stop Purpose Groups
   useEffect(() => {
     axios
@@ -276,54 +297,6 @@ function TrafficStops(props) {
     }
   }, [stopsChartState.data[STOPS], year]);
 
-  // Build data for Stops By Count line chart ("All")
-  useEffect(() => {
-    const data = reasonChartState.data[STOPS];
-    if (data && purpose === PURPOSE_DEFAULT) {
-      const derivedData = countEthnicGroups
-        .filter((g) => g.selected)
-        .map((r) => {
-          const race = r.value;
-          const rGroup = {
-            id: race,
-            color: theme.colors.ethnicGroup[race],
-          };
-          rGroup.data = data.map((d) => ({
-            displayName: toTitleCase(race),
-            // eslint-disable-next-line no-nested-ternary
-            x: pickerActive !== null ? (pickerXAxis === 'Month' ? d.date : d.year) : d.year,
-            y: d[race],
-          }));
-          return rGroup;
-        });
-      setByCountLineData(derivedData);
-    }
-  }, [reasonChartState.data[STOPS], purpose, countEthnicGroups, pickerActive]);
-
-  // Build data for Stops By Count line chart (single purpose)
-  useEffect(() => {
-    const data = reasonChartState.data[STOPS_BY_REASON]?.stops;
-    if (data && purpose !== PURPOSE_DEFAULT) {
-      const purposeData = filterSinglePurpose(data, purpose);
-      const derivedData = countEthnicGroups
-        .filter((g) => g.selected)
-        .map((r) => {
-          const race = r.value;
-          return {
-            id: race,
-            color: theme.colors.ethnicGroup[race],
-            data: purposeData.map((d) => ({
-              displayName: toTitleCase(race),
-              // eslint-disable-next-line no-nested-ternary
-              x: pickerActive !== null ? (pickerXAxis === 'Month' ? d.date : d.year) : d.year,
-              y: d[race],
-            })),
-          };
-        });
-      setByCountLineData(derivedData);
-    }
-  }, [reasonChartState.data[STOPS_BY_REASON], purpose, countEthnicGroups, pickerActive]);
-
   /* INTERACTIONS */
   // Handle year dropdown state
   const handleYearSelect = (y) => {
@@ -332,20 +305,10 @@ function TrafficStops(props) {
   };
 
   // Handle stop purpose dropdown state
-  const handleStopPurposeSelect = async (p) => {
+  const handleStopPurposeSelect = (p, i) => {
     if (p === purpose) return;
-    if (p === PURPOSE_DEFAULT) {
-      setPickerActive(null);
-      // Reset the chart data
-      const getEndpoint = mapDatasetKeyToEndpoint(STOPS);
-      const { data } = await axios.get(getEndpoint(agencyId));
-      reasonChartState.data[STOPS] = data;
-      setReasonChartYearSet(range(2002, new Date().getFullYear() + 1, 2));
-      setForcePickerRerender(false);
-    } else if (pickerActive !== null) {
-      setForcePickerRerender(true);
-    }
     setPurpose(p);
+    setTrafficStopsByCountPurpose(i);
   };
 
   // Handle stops by percentage legend interactions
@@ -356,16 +319,6 @@ function TrafficStops(props) {
     const updatedGroups = [...percentageEthnicGroups];
     updatedGroups[groupIndex].selected = !updatedGroups[groupIndex].selected;
     setPercentageEthnicGroups(updatedGroups);
-  };
-
-  // Handle stops by count legend interactions
-  const handleCountKeySelected = (ethnicGroup) => {
-    const groupIndex = countEthnicGroups.indexOf(
-      countEthnicGroups.find((g) => g.value === ethnicGroup.value)
-    );
-    const updatedGroups = [...countEthnicGroups];
-    updatedGroups[groupIndex].selected = !updatedGroups[groupIndex].selected;
-    setCountEthnicGroups(updatedGroups);
   };
 
   // Handle stops grouped by purpose legend interactions
@@ -479,40 +432,11 @@ function TrafficStops(props) {
   };
 
   const updateStopsByCount = (val) => {
-    setReasonChartYearSet(val.yearRange);
-    if (purpose !== PURPOSE_DEFAULT) {
-      reasonChartState.data[STOPS_BY_REASON] = val.data;
-    } else {
-      reasonChartState.data[STOPS] = val.data;
-    }
-    setPickerXAxis(val.xAxis);
-    setPickerActive((oldVal) => (oldVal === null ? true : !oldVal));
+    setTrafficStopsByCountRange(val);
   };
-
-  const lineAxisFormat = (t) => {
-    if (pickerActive !== null) {
-      if (pickerXAxis === 'Month') {
-        if (typeof t === 'string') {
-          // Month label is YYYY-MM
-          const month = new Date(t).getMonth() + 1;
-          let datasetLength;
-          if (purpose !== PURPOSE_DEFAULT) {
-            datasetLength = reasonChartState.data[STOPS_BY_REASON]?.stops.length;
-          } else {
-            datasetLength = reasonChartState.data[STOPS].length;
-          }
-          if (datasetLength > 10 && datasetLength <= 15) {
-            return month % 2 === 0 ? t : null;
-          }
-          if (datasetLength > 15) {
-            return month % 3 === 0 ? t : null;
-          }
-        }
-
-        return t;
-      }
-    }
-    return t % 2 === 0 ? t : null;
+  const closeStopsByCountRange = () => {
+    setPickerActive(null);
+    setTrafficStopsByCountRange(null);
   };
 
   const handleChange = (nextChecked) => {
@@ -679,18 +603,15 @@ function TrafficStops(props) {
         <ChartHeader chartTitle="Traffic Stops By Count" handleViewData={handleViewCountData} />
         <P>Shows the number of traffics stops broken down by purpose and race / ethnicity.</P>
         <S.ChartSubsection showCompare={props.showCompare}>
-          <S.LineWrapper>
-            <Line
-              data={byCountLineData}
-              loading={reasonChartState.loading[STOPS_BY_REASON]}
-              iTickFormat={lineAxisFormat}
-              iTickValues={reasonChartYearSet}
-              dAxisProps={{
-                tickFormat: (t) => `${t}`,
-              }}
-              xAxisLabel={pickerActive !== null ? pickerXAxis : 'Year'}
-            />
-          </S.LineWrapper>
+          <LineWrapper visible>
+            <StopGroupsContainer>
+              <LineChart
+                data={trafficStopsByCount}
+                title="Traffic Stops By Count"
+                maintainAspectRatio={false}
+              />
+            </StopGroupsContainer>
+          </LineWrapper>
           <S.LegendBeside>
             <DataSubsetPicker
               label="Stop Purpose"
@@ -704,21 +625,10 @@ function TrafficStops(props) {
             )}
 
             <MonthRangePicker
-              agencyId={agencyId}
-              dataSet={purpose !== PURPOSE_DEFAULT ? STOPS_BY_REASON : STOPS}
               deactivatePicker={pickerActive === null}
-              forcePickerRerender={forcePickerRerender}
               onChange={updateStopsByCount}
-              onClosePicker={() => setPickerActive(null)}
+              onClosePicker={closeStopsByCountRange}
             />
-            <S.Spacing>
-              <Legend
-                heading="Show on graph:"
-                keys={countEthnicGroups}
-                onKeySelect={handleCountKeySelected}
-                showNonHispanic
-              />
-            </S.Spacing>
           </S.LegendBeside>
         </S.ChartSubsection>
       </S.ChartSection>

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.styled.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.styled.js
@@ -8,7 +8,7 @@ export const LineWrapper = styled.div`
   display: ${(props) => (props.visible ? 'flex' : 'none')};
   flex-direction: row;
   flex-wrap: no-wrap;
-  width: 85%%;
+  width: 85%;
   margin: 0 auto;
   justify-content: space-evenly;
 

--- a/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
+++ b/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
@@ -29,7 +29,6 @@ import toTitleCase from '../../../util/toTitleCase';
 import useOfficerId from '../../../Hooks/useOfficerId';
 import GroupedBar from '../ChartPrimitives/GroupedBar';
 import Pie from '../ChartPrimitives/Pie';
-import MonthRangePicker from '../../Elements/MonthRangePicker';
 
 function UseOfForce(props) {
   const { agencyId, showCompare } = props;
@@ -39,8 +38,8 @@ function UseOfForce(props) {
   const [chartState] = useDataset(agencyId, USE_OF_FORCE);
 
   const [year, setYear] = useState(YEARS_DEFAULT);
-  const [pickerActive, setPickerActive] = useState(null);
-  const [pickerXAxis, setPickerXAxis] = useState(null);
+  const [pickerActive] = useState(null);
+  const [pickerXAxis] = useState(null);
 
   const [ethnicGroupKeys, setEthnicGroupKeys] = useState(() =>
     STATIC_LEGEND_KEYS.map((k) => ({ ...k }))
@@ -129,14 +128,6 @@ function UseOfForce(props) {
     openModal(USE_OF_FORCE, TABLE_COLUMNS);
   };
 
-  const updateUseOfForce = (val) => {
-    chartState.yearSet = val.yearRange;
-    chartState.data[USE_OF_FORCE] = val.data;
-
-    setPickerXAxis(val.xAxis);
-    setPickerActive((oldVal) => !oldVal);
-  };
-
   const lineAxisFormat = (t) => {
     if (pickerActive) {
       return t;
@@ -191,12 +182,6 @@ function UseOfForce(props) {
               options={[YEARS_DEFAULT].concat(chartState.yearRange)}
               dropUp
             />
-            {/* <MonthRangePicker */}
-            {/*  agencyId={agencyId} */}
-            {/*  dataSet={USE_OF_FORCE} */}
-            {/*  onChange={updateUseOfForce} */}
-            {/*  onClosePicker={() => setPickerActive(null)} */}
-            {/* /> */}
           </S.PieSection>
         </S.ChartSubsection>
       </S.ChartSection>

--- a/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
+++ b/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
@@ -191,12 +191,12 @@ function UseOfForce(props) {
               options={[YEARS_DEFAULT].concat(chartState.yearRange)}
               dropUp
             />
-            <MonthRangePicker
-              agencyId={agencyId}
-              dataSet={USE_OF_FORCE}
-              onChange={updateUseOfForce}
-              onClosePicker={() => setPickerActive(null)}
-            />
+            {/* <MonthRangePicker */}
+            {/*  agencyId={agencyId} */}
+            {/*  dataSet={USE_OF_FORCE} */}
+            {/*  onChange={updateUseOfForce} */}
+            {/*  onClosePicker={() => setPickerActive(null)} */}
+            {/* /> */}
           </S.PieSection>
         </S.ChartSubsection>
       </S.ChartSection>

--- a/frontend/src/Components/Elements/MonthRangePicker.js
+++ b/frontend/src/Components/Elements/MonthRangePicker.js
@@ -2,31 +2,10 @@ import Button from './Button';
 import * as ChartHeaderStyles from '../Charts/ChartSections/ChartHeader.styled';
 import { ICONS } from '../../img/icons/Icon';
 import React, { forwardRef, useEffect, useState } from 'react';
-import mapDatasetKeyToEndpoint from '../../Services/endpoints';
-import axios from '../../Services/Axios';
-import {
-  CONTRABAND_HIT_RATE,
-  LIKELIHOOD_OF_SEARCH,
-  SEARCHES,
-  SEARCHES_BY_TYPE,
-  STOPS,
-  STOPS_BY_REASON,
-  USE_OF_FORCE,
-} from '../../Hooks/useDataset';
+
 import { useTheme } from 'styled-components';
-import range from 'lodash.range';
 import DatePicker from 'react-datepicker';
 import { getRangeValues } from '../../util/range';
-
-const mapDataSetToEnum = {
-  STOPS,
-  SEARCHES,
-  STOPS_BY_REASON,
-  SEARCHES_BY_TYPE,
-  USE_OF_FORCE,
-  CONTRABAND_HIT_RATE,
-  LIKELIHOOD_OF_SEARCH,
-};
 
 const MonthPickerButton = forwardRef(({ value, onClick }, ref) => (
   <Button onClick={onClick} ref={ref}>
@@ -34,14 +13,7 @@ const MonthPickerButton = forwardRef(({ value, onClick }, ref) => (
   </Button>
 ));
 
-export default function MonthRangePicker({
-  agencyId,
-  dataSet,
-  deactivatePicker,
-  forcePickerRerender,
-  onChange,
-  onClosePicker,
-}) {
+export default function MonthRangePicker({ deactivatePicker, onChange, onClosePicker }) {
   const theme = useTheme();
   const startYear = new Date().setFullYear(2000, 1, 1);
   const [showDateRangePicker, setShowDateRangePicker] = useState(false);
@@ -58,19 +30,6 @@ export default function MonthRangePicker({
     }
   }, [deactivatePicker]);
 
-  useEffect(() => {
-    const rerenderData = async () => {
-      const rangeVal = {
-        from: { month: startDate.getMonth() + 1, year: startDate.getFullYear() },
-        to: { month: endDate.getMonth() + 1, year: endDate.getFullYear() },
-      };
-      await updateDatePicker(rangeVal);
-    };
-    if (forcePickerRerender) {
-      rerenderData().catch((err) => console.log(err));
-    }
-  }, [forcePickerRerender]);
-
   const showDatePicker = () => {
     const rangeValues = getRangeValues();
     setStartDate(new Date().setFullYear(rangeValues.from.year, 1));
@@ -85,39 +44,8 @@ export default function MonthRangePicker({
     setEndDate(new Date());
     setMinDate(null);
 
-    await updateDatePicker(rangeValues);
+    onChange(null);
     onClosePicker();
-  };
-
-  const updateDatePicker = async (rangeVal) => {
-    let tableDS = mapDataSetToEnum[dataSet];
-    if (Array.isArray(dataSet)) {
-      tableDS = mapDataSetToEnum[dataSet[1]];
-    }
-    const getEndpoint = mapDatasetKeyToEndpoint(tableDS);
-    const _from = `${rangeVal.from.year}-${rangeVal.from.month.toString().padStart(2, 0)}-01`;
-    const _to = `${rangeVal.to.year}-${rangeVal.to.month.toString().padStart(2, 0)}-01`;
-    const url = `${getEndpoint(agencyId)}?from=${_from}&to=${_to}`;
-
-    const fromDate = new Date(_from);
-    fromDate.setDate(fromDate.getDate() + 1); // To prevent getting last month's date in new year
-    fromDate.toLocaleString('en-US', { timeZone: 'America/New_York' });
-    const toDate = new Date(_to);
-    toDate.setDate(toDate.getDate() + 1); // To prevent getting last month's date in new year
-    toDate.toLocaleString('en-US', { timeZone: 'America/New_York' });
-
-    const diffYears = toDate.getFullYear() - fromDate.getFullYear();
-    let xAxis = 'Year';
-    const yearRange = range(rangeVal.from.year, rangeVal.to.year + 1, 1);
-    if (diffYears < 3) {
-      xAxis = 'Month';
-    }
-    try {
-      const { data } = await axios.get(url);
-      onChange({ data, xAxis, yearRange });
-    } catch (err) {
-      console.log(err);
-    }
   };
 
   const onDateRangeChange = async (dates) => {
@@ -143,7 +71,7 @@ export default function MonthRangePicker({
         from: { month: start.getMonth() + 1, year: start.getFullYear() },
         to: { month: end.getMonth() + 1, year: end.getFullYear() },
       };
-      await updateDatePicker(rangeVal);
+      onChange(rangeVal);
     }
   };
 

--- a/frontend/src/Components/NewCharts/LineChart.js
+++ b/frontend/src/Components/NewCharts/LineChart.js
@@ -27,6 +27,7 @@ export default function LineChart({
   yAxisMax = null,
   yAxisShowLabels = true,
   displayStopPurposeTooltips = false,
+  showLegendOnBottom = true,
 }) {
   const options = {
     responsive: true,
@@ -38,7 +39,7 @@ export default function LineChart({
     plugins: {
       legend: {
         display: displayLegend,
-        position: 'top',
+        position: showLegendOnBottom ? 'bottom' : 'top',
         onHover(event, legendItem) {
           if (displayStopPurposeTooltips) {
             setTooltipText(tooltipLanguage(legendItem.text));

--- a/nc/urls.py
+++ b/nc/urls.py
@@ -16,6 +16,10 @@ urlpatterns = [  # noqa
     re_path(r"^api/", include(router.urls)),
     path("api/about/contact/", csrf_exempt(views.ContactView.as_view()), name="contact-form"),
     path(
+        "api/agency/<int:agency_id>/stops-by-count/",
+        views.AgencyTrafficStopsByCountView.as_view(),
+    ),
+    path(
         "api/agency/<int:agency_id>/stop-purpose-groups/",
         views.AgencyStopPurposeGroupView.as_view(),
     ),

--- a/nc/views.py
+++ b/nc/views.py
@@ -79,6 +79,26 @@ class QueryKeyConstructor(DefaultObjectKeyConstructor):
 query_cache_key_func = QueryKeyConstructor()
 
 
+def get_date_range(request):
+    # Only filter is from and to values are found and are valid
+    date_precision = "year"
+    date_range = Q()
+    _from_date = request.query_params.get("from", None)
+    _to_date = request.query_params.get("to", None)
+    if _from_date and _to_date:
+        from_date = datetime.datetime.strptime(_from_date, "%Y-%m-%d")
+        to_date = datetime.datetime.strptime(_to_date, "%Y-%m-%d")
+        if from_date and to_date:
+            delta = relativedelta.relativedelta(to_date, from_date)
+            if delta.years < 3:
+                date_precision = "month"
+                to_date = (to_date + relativedelta.relativedelta(months=1)) - datetime.timedelta(
+                    days=1
+                )
+            date_range = Q(date__range=(from_date, to_date))
+    return date_precision, date_range
+
+
 class AgencyViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Agency.objects.all()
     serializer_class = serializers.AgencySerializer
@@ -92,25 +112,6 @@ class AgencyViewSet(viewsets.ReadOnlyModelViewSet):
             qs = qs.filter(agency=agency)
         return qs
 
-    def get_date_range(self):
-        # Only filter is from and to values are found and are valid
-        date_precision = "year"
-        date_range = Q()
-        _from_date = self.request.query_params.get("from", None)
-        _to_date = self.request.query_params.get("to", None)
-        if _from_date and _to_date:
-            from_date = datetime.datetime.strptime(_from_date, "%Y-%m-%d")
-            to_date = datetime.datetime.strptime(_to_date, "%Y-%m-%d")
-            if from_date and to_date:
-                delta = relativedelta.relativedelta(to_date, from_date)
-                if delta.years < 3:
-                    date_precision = "month"
-                    to_date = (
-                        to_date + relativedelta.relativedelta(months=1)
-                    ) - datetime.timedelta(days=1)
-                date_range = Q(date__range=(from_date, to_date))
-        return date_precision, date_range
-
     def query(self, results, group_by, filter_=None):
         qs = self.get_stopsummary_qs(agency=self.get_object())
         # filter down by officer if supplied
@@ -121,7 +122,7 @@ class AgencyViewSet(viewsets.ReadOnlyModelViewSet):
             qs = qs.filter(filter_)
 
         group_by_tuple = group_by
-        date_precision, date_range = self.get_date_range()
+        date_precision, date_range = get_date_range(self.request)
         qs = qs.filter(date_range)
         if date_precision == "year":
             qs = qs.annotate(year=ExtractYear("date"))
@@ -371,6 +372,95 @@ class ContactView(APIView):
             return Response(status=204)
         else:
             return Response(data=serializer.errors, status=400)
+
+
+# def get_values(df, years, col, purpose=None):
+#     if purpose:
+#         if col in df[purpose]:
+#             return list(df[purpose][col].values)
+#     elif purpose == "All":
+#         pass
+#
+#     return [0] * len(years)
+
+
+class AgencyTrafficStopsByCountView(APIView):
+    def build_response(self, df, x_range, purpose=None):
+        def get_values(race):
+            if purpose:
+                if race in df[purpose]:
+                    return list(df[purpose][race].values)
+            elif purpose is None:
+                return list(df[race].values)
+
+            return [0] * len(x_range)
+
+        return {
+            "labels": x_range,
+            "datasets": [
+                {
+                    "label": "White",
+                    "data": get_values("White"),
+                    "borderColor": "#02bcbb",
+                    "backgroundColor": "#80d9d8",
+                },
+                {
+                    "label": "Black",
+                    "data": get_values("Black"),
+                    "borderColor": "#8879fc",
+                    "backgroundColor": "#beb4fa",
+                },
+                {
+                    "label": "Hispanic",
+                    "data": get_values("Hispanic"),
+                    "borderColor": "#9c0f2e",
+                    "backgroundColor": "#ca8794",
+                },
+                {
+                    "label": "Asian",
+                    "data": get_values("Asian"),
+                    "borderColor": "#ffe066",
+                    "backgroundColor": "#ffeeb2",
+                },
+                {
+                    "label": "Native American",
+                    "data": get_values("Native American"),
+                    "borderColor": "#0c3a66",
+                    "backgroundColor": "#8598ac",
+                },
+                {
+                    "label": "Other",
+                    "data": get_values("Other"),
+                    "borderColor": "#9e7b9b",
+                    "backgroundColor": "#cab6c7",
+                },
+            ],
+        }
+
+    def get(self, request, agency_id):
+        date_precision, date_range = get_date_range(request)
+        qs = StopSummary.objects.filter(agency_id=agency_id).filter(date_range)
+
+        if date_precision == "year":
+            qs = qs.annotate(year=ExtractYear("date"))
+        else:
+            date_precision = "date"
+
+        qs_df_cols = ["driver_race_comb"]
+        stop_purpose = int(request.query_params.get("purpose", 0))
+        if stop_purpose != 0:
+            qs_df_cols.insert(0, "stop_purpose")
+        qs_values = [date_precision] + qs_df_cols
+
+        qs = qs.values(*qs_values).annotate(count=Sum("count")).order_by(date_precision)
+        df = pd.DataFrame(qs)
+        unique_x_range = df[date_precision].unique()
+        pivot_df = df.pivot(index=date_precision, columns=qs_df_cols, values="count").fillna(
+            value=0
+        )
+        df = pd.DataFrame(pivot_df)
+        data = self.build_response(df, unique_x_range, stop_purpose if stop_purpose != 0 else None)
+        return Response(data=data, status=200)
 
 
 class AgencyStopPurposeGroupView(APIView):


### PR DESCRIPTION
Tickets:
- https://app.clickup.com/t/868580qgz
- https://app.clickup.com/t/868580eqa

What's changed:
- Swaps out the traffic stops by count graph to the new chartjs line chart, further simplifying the logic + code
- Adds separate view in backend to return data only for traffic stops by count
- Removed dead code on the frontend

Preview:
![Screenshot 2023-08-07 at 5 35 48 PM](https://github.com/caktus/Traffic-Stops/assets/26633909/628a5094-a2b8-4b35-8e08-2db835b98fba)
