### PR TITLE
Expand list of urls for prime caching

### DIFF
--- a/nc/prime_cache.py
+++ b/nc/prime_cache.py
@@ -18,6 +18,9 @@ API_ENDPOINT_NAMES = (
     "nc:agency-api-searches-by-type",
     "nc:agency-api-contraband-hit-rate",
     "nc:agency-api-use-of-force",
+    "nc:stops-by-count",
+    "nc:stop-purpose-groups",
+    "nc:stops-grouped-by-purpose",
 )
 DEFAULT_CUTOFF_SECS = 4
 

--- a/nc/urls.py
+++ b/nc/urls.py
@@ -18,13 +18,16 @@ urlpatterns = [  # noqa
     path(
         "api/agency/<agency_id>/stops-by-count/",
         views.AgencyTrafficStopsByCountView.as_view(),
+        name="stops-by-count",
     ),
     path(
         "api/agency/<agency_id>/stop-purpose-groups/",
         views.AgencyStopPurposeGroupView.as_view(),
+        name="stop-purpose-groups",
     ),
     path(
         "api/agency/<agency_id>/stops-grouped-by-purpose/",
         views.AgencyStopGroupByPurposeView.as_view(),
+        name="stops-grouped-by-purpose",
     ),
 ]


### PR DESCRIPTION
- Add the new traffic stops api endpoints to the list of urls the backend uses to cache the expensive views for the frontend graphs