### PR TITLE
Fix footer not pinned to bottom of screen when comparing agencies

### DIFF
--- a/frontend/src/Components/Charts/ChartSections/ChartPageBase.styled.js
+++ b/frontend/src/Components/Charts/ChartSections/ChartPageBase.styled.js
@@ -7,10 +7,12 @@ export const ChartPageBase = styled(motion.article)`
   height: 100%;
   overflow-y: hidden;
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 `;
 
 export const ChartPageContent = styled.div`
-  margin: 0 auto;
   padding: 1.5em 6em 3em 4em;
   overflow: hidden;
 


### PR DESCRIPTION
What's changed:
- Update how the content is displayed for chart pages, expanding the page to fill the remaining white space under the footer to keep it consistent with the other compared agency page. 