### PR TITLE
Update contraband colors and allow resource titles to be italicized

### DIFF
--- a/frontend/src/Components/Charts/Contraband/Contraband.js
+++ b/frontend/src/Components/Charts/Contraband/Contraband.js
@@ -258,9 +258,9 @@ function Contraband(props) {
       .get(url)
       .then((res) => {
         const colors = {
-          'Safety Violation': '#b173bc',
-          'Regulatory Equipment': '#e69500',
-          Other: '#7dd082',
+          'Safety Violation': '#7F428A',
+          'Regulatory Equipment': '#b36800',
+          Other: '#359679',
         };
         const stopPurposeDataSets = res.data.contraband_percentages.map((ds) => ({
           axis: 'x',

--- a/frontend/src/Components/ResourcePage/ResourcePage.js
+++ b/frontend/src/Components/ResourcePage/ResourcePage.js
@@ -17,7 +17,7 @@ function Resource({ resource }) {
         <S.ResourceImage src={resource.image_url} alt={resource.title} />
       </div>
       <div>
-        <H2>{resource.title} </H2>
+        <H2 dangerouslySetInnerHTML={{ __html: resource.title }} />
         {resource.publication_date && <P size={14}>{resourcePublicationDate}</P>}
         <P size={18} dangerouslySetInnerHTML={{ __html: resource.description }} />
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: '5px' }}>

--- a/nc/admin.py
+++ b/nc/admin.py
@@ -56,6 +56,7 @@ class InlineResourceFile(admin.StackedInline):
 
 class ResourceForm(forms.ModelForm):
     # https://django-ckeditor.readthedocs.io/en/latest/#widget
+    title = forms.CharField(widget=CKEditorWidget())
     description = forms.CharField(widget=CKEditorWidget())
 
     class Meta:
@@ -74,7 +75,7 @@ class ResourceAdmin(admin.ModelAdmin):
         "view_more_link",
     )
     list_display = (
-        "title",
+        "__str__",
         "created_date",
         "publication_date",
     )

--- a/nc/models.py
+++ b/nc/models.py
@@ -1,5 +1,6 @@
 from caching.base import CachingManager, CachingMixin
 from django.db import models
+from django.utils.html import format_html
 from django_pgviews import view as pg
 
 from tsdata.models import CensusProfile
@@ -418,7 +419,7 @@ class Resource(models.Model):
         ordering = ("-created_date",)
 
     def __str__(self):
-        return f"{self.title}"
+        return format_html(self.title)
 
 
 class ResourceFile(models.Model):


### PR DESCRIPTION
What's changed:
- Update second Contraband graph with darker colors
- Allow resource title on frontend to be italicized + more 

Preview:
![Screenshot 2023-12-06 at 11 51 13 AM](https://github.com/caktus/Traffic-Stops/assets/26633909/27fd7e2c-c0da-4986-b1b0-494c0d8582e9)
![Screenshot 2023-12-06 at 11 53 11 AM](https://github.com/caktus/Traffic-Stops/assets/26633909/fa0b8244-39cd-4147-ba75-7a37f8488a00)


