### PR TITLE
Update traffic stop colors and contraband table modal wording

### DIFF
--- a/frontend/src/Components/Charts/Contraband/Contraband.js
+++ b/frontend/src/Components/Charts/Contraband/Contraband.js
@@ -271,7 +271,6 @@ function Contraband(props) {
           fill: false,
           backgroundColor: colors[ds.stop_purpose],
           borderColor: colors[ds.stop_purpose],
-          hoverBackgroundColor: colors[ds.stop_purpose],
           borderWidth: 1,
         }));
         const data = {
@@ -573,7 +572,7 @@ function Contraband(props) {
         </S.ChartDescription>
         <NewModal
           tableHeader='Contraband "Hit Rate" Grouped By Stop Purpose'
-          tableSubheader="Shows what percentage of searches led to the discovery of illegal items broken down by race/ethnicity and original stop purpose."
+          tableSubheader="Shows what number of searches led to the discovery of illegal items by race/ethnicity and original stop purpose."
           agencyName={chartState.data[AGENCY_DETAILS].name}
           tableData={contrabandStopPurposeModalData.tableData}
           csvData={contrabandStopPurposeModalData.csvData}
@@ -602,7 +601,7 @@ function Contraband(props) {
               modalConfig={{
                 tableHeader: 'Contraband "Hit Rate" Grouped By Stop Purpose',
                 tableSubheader: getBarChartModalSubHeading(
-                  'Shows what percentage of searches led to the discovery of illegal items broken down by race/ethnicity and original stop purpose'
+                  'Shows what number of searches led to the discovery of illegal items by race/ethnicity and original stop purpose'
                 ),
                 agencyName: chartState.data[AGENCY_DETAILS].name,
                 chartTitle: getBarChartModalHeading(
@@ -632,7 +631,7 @@ function Contraband(props) {
           <P>Shows what percentage of searches discovered specific types of illegal items.</P>
           <NewModal
             tableHeader='Contraband "Hit Rate" by type'
-            tableSubheader="Shows what percentage of searches discovered specific types of illegal items."
+            tableSubheader="Shows what number of searches discovered specific types of illegal items."
             agencyName={chartState.data[AGENCY_DETAILS].name}
             tableData={contrabandTypesData.tableData}
             csvData={contrabandTypesData.csvData}
@@ -652,7 +651,7 @@ function Contraband(props) {
               modalConfig={{
                 tableHeader: 'Contraband "Hit Rate" by type',
                 tableSubheader: getBarChartModalSubHeading(
-                  'Shows what percentage of searches discovered specific types of illegal items'
+                  'Shows what number of searches discovered specific types of illegal items'
                 ),
                 agencyName: chartState.data[AGENCY_DETAILS].name,
                 chartTitle: getBarChartModalHeading(

--- a/nc/views.py
+++ b/nc/views.py
@@ -607,20 +607,20 @@ class AgencyStopPurposeGroupView(APIView):
                 {
                     "label": StopPurposeGroup.SAFETY_VIOLATION,
                     "data": self.get_values(df, StopPurposeGroup.SAFETY_VIOLATION, years_len),
-                    "borderColor": "#7F428A",
-                    "backgroundColor": "#CFA9D6",
+                    "borderColor": "#5F0F40",
+                    "backgroundColor": "#5F0F40",
                 },
                 {
                     "label": StopPurposeGroup.REGULATORY_EQUIPMENT,
                     "data": self.get_values(df, StopPurposeGroup.REGULATORY_EQUIPMENT, years_len),
-                    "borderColor": "#b36800",
-                    "backgroundColor": "#ffa500",
+                    "borderColor": "#E36414",
+                    "backgroundColor": "#E36414",
                 },
                 {
                     "label": StopPurposeGroup.OTHER,
                     "data": self.get_values(df, StopPurposeGroup.OTHER, years_len),
-                    "borderColor": "#1B4D3E",
-                    "backgroundColor": "#ACE1AF",
+                    "borderColor": "#0F4C5C",
+                    "backgroundColor": "#0F4C5C",
                 },
             ],
         }


### PR DESCRIPTION
What's changed:
- Match traffic stops by stop purpose graph colors to the contraband percentages by stop purpose
- Update wording of contraband modal subheading to correctly match description of data -> percentage to integers