### PR TITLE
Update prime cache

### DIFF
--- a/nc/management/commands/prime_cache.py
+++ b/nc/management/commands/prime_cache.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
         )
         parser.add_argument("--clear-cache", "-c", action="store_true", default=False)
         parser.add_argument("--skip-agencies", action="store_true", default=False)
-        parser.add_argument("--skip-officers", action="store_true", default=False)
+        parser.add_argument("--skip-officers", action="store_true", default=True)
         parser.add_argument(
             "--officer-cutoff-count",
             type=int,

--- a/nc/prime_cache.py
+++ b/nc/prime_cache.py
@@ -123,7 +123,7 @@ class CachePrimer:
 
     def prime(self):
         logger.info(f"{self} starting")
-        self.count = self.get_queryset().count()
+        self.count = len(self.get_queryset())
         logger.info(f"{self} priming {self.count:,} objects")
         for endpoints in self.get_endpoints():
             for endpoint in endpoints:
@@ -140,13 +140,24 @@ class CachePrimer:
 
 class AgencyStopsPrimer(CachePrimer):
     def get_queryset(self):
-        return (
+        qs = list(
             Stop.objects.no_cache()
             .annotate(agency_name=F("agency_description"))
             .values("agency_name", "agency_id")
             .annotate(num_stops=Count("stop_id"))
             .order_by("-num_stops")
         )
+        # Manually insert the statewide to force the caching since a
+        # stop instance won't directly be associated with the statewide agency id.
+        qs.insert(
+            0,
+            {
+                "agency_name": "North Carolina State",
+                "agency_id": -1,
+                "num_stops": Stop.objects.count(),
+            },
+        )
+        return qs
 
     def get_urls(self, row):
         urls = []
@@ -177,7 +188,7 @@ def run(
     cutoff_duration_secs=None,
     clear_cache=False,
     skip_agencies=False,
-    skip_officers=False,
+    skip_officers=True,
     officer_cutoff_count=None,
 ):
     """
@@ -216,6 +227,6 @@ def run(
     if not skip_officers:
         OfficerStopsPrimer(
             cutoff_secs=0, cutoff_count=officer_cutoff_count
-        ).prime()  # cache all officer endpoins for now
+        ).prime()  # cache all officer endpoints for now
 
     logger.info("Complete")

--- a/nc/tests/test_prime_cache.py
+++ b/nc/tests/test_prime_cache.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from nc.models import Agency
 from nc.prime_cache import run
 from nc.tests import factories
 
@@ -13,6 +14,8 @@ class PrimeCacheTests(TestCase):
     databases = "__all__"
 
     def test_prime_cache(self):
+        factories.AgencyFactory(id=-1)  # Statewide data
+
         factories.ContrabandFactory()
         factories.ContrabandFactory()
         factories.ContrabandFactory()


### PR DESCRIPTION
What's changed:
- Skip officers for now in the prime cache run method
- Include statewide data in the list of agencies for AgencyCachePrimer