### PR TITLE
Add arrests percentages by searches graph

### DIFF
--- a/frontend/src/Components/AgencyData/AgencyData.js
+++ b/frontend/src/Components/AgencyData/AgencyData.js
@@ -67,7 +67,13 @@ function AgencyData(props) {
             </motion.div>
           )}
         </AnimatePresence>
-        {chartsOpen && <ChartRoutes agencyId={agencyId} showCompare={props.showCompare} />}
+        {chartsOpen && (
+          <ChartRoutes
+            agencyId={agencyId}
+            showCompare={props.showCompare}
+            agencyName={chartState.data[AGENCY_DETAILS].name}
+          />
+        )}
       </S.ContentWrapper>
     </S.AgencyData>
   );

--- a/frontend/src/Components/Charts/Arrest/Arrests.js
+++ b/frontend/src/Components/Charts/Arrest/Arrests.js
@@ -10,8 +10,9 @@ import useTableModal from '../../../Hooks/useTableModal';
 
 // Children
 import DataSubsetPicker from '../ChartSections/DataSubsetPicker/DataSubsetPicker';
-import ArrestsByPercentage from './Charts/ArrestsByPercentage';
+import PercentageOfStops from './Charts/PercentageOfStops';
 import useYearSet from '../../../Hooks/useYearSet';
+import PercentageOfSearches from './Charts/PercentageOfSearches';
 
 function Arrests(props) {
   const [year, setYear] = useState(YEARS_DEFAULT);
@@ -44,9 +45,45 @@ function Arrests(props) {
           dropDown
         />
       </div>
-      <ArrestsByPercentage {...props} year={year} />
+      <PercentageOfStops {...props} year={year} />
+      <PercentageOfSearches {...props} year={year} />
     </ArrestsStyled>
   );
 }
 
 export default Arrests;
+
+export const ARRESTS_TABLE_COLUMNS = [
+  {
+    Header: 'Year',
+    accessor: 'year', // accessor is the "key" in the data
+  },
+  {
+    Header: 'White*',
+    accessor: 'white',
+  },
+  {
+    Header: 'Black*',
+    accessor: 'black',
+  },
+  {
+    Header: 'Native American*',
+    accessor: 'native_american',
+  },
+  {
+    Header: 'Asian*',
+    accessor: 'asian',
+  },
+  {
+    Header: 'Other*',
+    accessor: 'other',
+  },
+  {
+    Header: 'Hispanic',
+    accessor: 'hispanic',
+  },
+  {
+    Header: 'Total',
+    accessor: 'total',
+  },
+];

--- a/frontend/src/Components/Charts/Arrest/Arrests.js
+++ b/frontend/src/Components/Charts/Arrest/Arrests.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import ArrestsStyled from './Arrests.styles';
+
+// Util
+import { YEARS_DEFAULT } from '../chartUtils';
+
+// Hooks
+import useMetaTags from '../../../Hooks/useMetaTags';
+import useTableModal from '../../../Hooks/useTableModal';
+
+// Children
+import DataSubsetPicker from '../ChartSections/DataSubsetPicker/DataSubsetPicker';
+import ArrestsByPercentage from './Charts/ArrestsByPercentage';
+import useYearSet from '../../../Hooks/useYearSet';
+
+function Arrests(props) {
+  const [year, setYear] = useState(YEARS_DEFAULT);
+  const [yearRange] = useYearSet();
+
+  const renderMetaTags = useMetaTags();
+  const [renderTableModal] = useTableModal();
+
+  useEffect(() => {
+    if (window.location.hash) {
+      document.querySelector(`${window.location.hash}`).scrollIntoView();
+    }
+  }, []);
+
+  const handleYearSelect = (y) => {
+    if (y === year) return;
+    setYear(y);
+  };
+
+  return (
+    <ArrestsStyled>
+      {renderMetaTags()}
+      {renderTableModal()}
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <DataSubsetPicker
+          label="Year"
+          value={year}
+          onChange={handleYearSelect}
+          options={[YEARS_DEFAULT].concat(yearRange)}
+          dropDown
+        />
+      </div>
+      <ArrestsByPercentage {...props} year={year} />
+    </ArrestsStyled>
+  );
+}
+
+export default Arrests;

--- a/frontend/src/Components/Charts/Arrest/Arrests.styles.js
+++ b/frontend/src/Components/Charts/Arrest/Arrests.styles.js
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+import ChartPageBase from '../ChartSections/ChartPageBase';
+import { smallerThanDesktop, smallerThanTabletLandscape } from '../../../styles/breakpoints';
+
+export default styled(ChartPageBase)``;
+
+export const ChartWrapper = styled.div`
+  width: 100%;
+  height: auto;
+`;
+
+export const HorizontalBarWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: no-wrap;
+  width: 100%;
+  margin: 0 auto;
+  justify-content: space-evenly;
+
+  @media (${smallerThanDesktop}) {
+    flex-wrap: wrap;
+  }
+`;
+
+export const BarContainer = styled.div`
+  width: 100%;
+  height: 500px;
+  @media (${smallerThanTabletLandscape}) {
+    width: 100%;
+  }
+  display: ${(props) => (props.visible ? 'block' : 'none')};
+`;

--- a/frontend/src/Components/Charts/Arrest/Charts/ArrestsByPercentage.js
+++ b/frontend/src/Components/Charts/Arrest/Charts/ArrestsByPercentage.js
@@ -1,0 +1,178 @@
+import React, { useEffect, useState } from 'react';
+import * as S from '../../ChartSections/ChartsCommon.styled';
+
+// Children
+import { P } from '../../../../styles/StyledComponents/Typography';
+import ChartHeader from '../../ChartSections/ChartHeader';
+import HorizontalBarChart from '../../../NewCharts/HorizontalBarChart';
+import axios from '../../../../Services/Axios';
+import useOfficerId from '../../../../Hooks/useOfficerId';
+import { ChartWrapper } from '../Arrests.styles';
+import NewModal from '../../../NewCharts/NewModal';
+
+function ArrestsByPercentage(props) {
+  const { agencyId, agencyName, showCompare, year } = props;
+
+  const officerId = useOfficerId();
+
+  const initArrestData = {
+    labels: [],
+    datasets: [],
+    isModalOpen: false,
+    tableData: [],
+    csvData: [],
+    loading: true,
+  };
+  const [arrestData, setArrestData] = useState(initArrestData);
+
+  useEffect(() => {
+    const params = [];
+    if (year && year !== 'All') {
+      params.push({ param: 'year', val: year });
+    }
+    if (officerId) {
+      params.push({ param: 'officer', val: officerId });
+    }
+
+    const urlParams = params.map((p) => `${p.param}=${p.val}`).join('&');
+    const url = `/api/agency/${agencyId}/arrests-by-percentage/?${urlParams}`;
+    axios
+      .get(url)
+      .then((res) => {
+        const tableData = [];
+        const resTableData = res.data.table_data.length
+          ? JSON.parse(res.data.table_data)
+          : { data: [] };
+        resTableData.data.forEach((e) => {
+          const dataCounts = { ...e };
+          delete dataCounts.year;
+          // Need to assign explicitly otherwise the download data orders columns by alphabet.
+          tableData.unshift({
+            year: e.year,
+            white: e.white,
+            black: e.black,
+            native_american: e.native_american,
+            asian: e.asian,
+            other: e.other,
+            hispanic: e.hispanic,
+            total: Object.values(dataCounts).reduce((a, b) => a + b, 0),
+          });
+        });
+        const colors = ['#02bcbb', '#8879fc', '#9c0f2e', '#ffe066', '#0c3a66', '#9e7b9b'];
+        const data = {
+          labels: ['White', 'Black', 'Hispanic', 'Asian', 'Native American', 'Other'],
+          datasets: [
+            {
+              axis: 'y',
+              label: 'All',
+              data: res.data.arrest_percentages,
+              fill: false,
+              backgroundColor: colors,
+              borderColor: colors,
+              hoverBackgroundColor: colors,
+              borderWidth: 1,
+            },
+          ],
+          isModalOpen: false,
+          tableData,
+          csvData: tableData,
+        };
+        setArrestData(data);
+      })
+      .catch((err) => console.log(err));
+  }, [year]);
+
+  const formatTooltipValue = (ctx) => `${(ctx.raw * 100).toFixed(2)}%`;
+
+  const subjectObserving = () => {
+    if (officerId) {
+      return 'by this officer';
+    }
+    if (agencyId === '-1') {
+      return 'for the entire state';
+    }
+    return 'by this department';
+  };
+
+  const getYearPhrase = () => (year && year !== 'All' ? ` in ${year}` : '');
+
+  const getBarChartModalSubHeading = (title) => `${title} ${subjectObserving()}${getYearPhrase()}`;
+
+  return (
+    <S.ChartSection>
+      <ChartHeader
+        chartTitle="Arrests By Percentage"
+        handleViewData={() => setArrestData((state) => ({ ...state, isOpen: true }))}
+      />
+      <S.ChartDescription>
+        <P>Percentage of stops that led to an arrest for a given race / ethnic group.</P>
+        <NewModal
+          tableHeader="Arrests By Percentage"
+          tableSubheader="Shows what percentage of stops led to an arrest for a given race / ethnic group."
+          agencyName={agencyName}
+          tableData={arrestData.tableData}
+          csvData={arrestData.csvData}
+          columns={ARRESTS_TABLE_COLUMNS}
+          tableDownloadName="Arrests_By_Percentage"
+          isOpen={arrestData.isOpen}
+          closeModal={() => setArrestData((state) => ({ ...state, isOpen: false }))}
+        />
+      </S.ChartDescription>
+      <S.ChartSubsection showCompare={showCompare}>
+        <ChartWrapper>
+          <HorizontalBarChart
+            title="Arrests By Percentage"
+            data={arrestData}
+            displayLegend={false}
+            tooltipLabelCallback={formatTooltipValue}
+            modalConfig={{
+              tableHeader: 'Arrests By Percentage',
+              tableSubheader: getBarChartModalSubHeading(
+                'Shows what percentage of stops led to an arrest for a given race / ethnic group'
+              ),
+              agencyName,
+              chartTitle: getBarChartModalSubHeading('Arrests By Percentage'),
+            }}
+          />
+        </ChartWrapper>
+      </S.ChartSubsection>
+    </S.ChartSection>
+  );
+}
+
+export default ArrestsByPercentage;
+
+const ARRESTS_TABLE_COLUMNS = [
+  {
+    Header: 'Year',
+    accessor: 'year', // accessor is the "key" in the data
+  },
+  {
+    Header: 'White*',
+    accessor: 'white',
+  },
+  {
+    Header: 'Black*',
+    accessor: 'black',
+  },
+  {
+    Header: 'Native American*',
+    accessor: 'native_american',
+  },
+  {
+    Header: 'Asian*',
+    accessor: 'asian',
+  },
+  {
+    Header: 'Other*',
+    accessor: 'other',
+  },
+  {
+    Header: 'Hispanic',
+    accessor: 'hispanic',
+  },
+  {
+    Header: 'Total',
+    accessor: 'total',
+  },
+];

--- a/frontend/src/Components/Charts/Arrest/Charts/PercentageOfSearches.js
+++ b/frontend/src/Components/Charts/Arrest/Charts/PercentageOfSearches.js
@@ -1,0 +1,144 @@
+import React, { useEffect, useState } from 'react';
+import * as S from '../../ChartSections/ChartsCommon.styled';
+
+// Children
+import { P } from '../../../../styles/StyledComponents/Typography';
+import ChartHeader from '../../ChartSections/ChartHeader';
+import HorizontalBarChart from '../../../NewCharts/HorizontalBarChart';
+import axios from '../../../../Services/Axios';
+import useOfficerId from '../../../../Hooks/useOfficerId';
+import { ChartWrapper } from '../Arrests.styles';
+import NewModal from '../../../NewCharts/NewModal';
+import { ARRESTS_TABLE_COLUMNS } from '../Arrests';
+
+function PercentageOfSearches(props) {
+  const { agencyId, agencyName, showCompare, year } = props;
+
+  const officerId = useOfficerId();
+
+  const initArrestData = {
+    labels: [],
+    datasets: [],
+    isModalOpen: false,
+    tableData: [],
+    csvData: [],
+    loading: true,
+  };
+  const [arrestData, setArrestData] = useState(initArrestData);
+
+  useEffect(() => {
+    const params = [];
+    if (year && year !== 'All') {
+      params.push({ param: 'year', val: year });
+    }
+    if (officerId) {
+      params.push({ param: 'officer', val: officerId });
+    }
+
+    const urlParams = params.map((p) => `${p.param}=${p.val}`).join('&');
+    const url = `/api/agency/${agencyId}/arrests-percentage-of-searches/?${urlParams}`;
+    axios
+      .get(url)
+      .then((res) => {
+        const tableData = [];
+        const resTableData = res.data.table_data.length
+          ? JSON.parse(res.data.table_data)
+          : { data: [] };
+        resTableData.data.forEach((e) => {
+          const dataCounts = { ...e };
+          delete dataCounts.year;
+          // Need to assign explicitly otherwise the download data orders columns by alphabet.
+          tableData.unshift({
+            year: e.year,
+            white: e.white,
+            black: e.black,
+            native_american: e.native_american,
+            asian: e.asian,
+            other: e.other,
+            hispanic: e.hispanic,
+            total: Object.values(dataCounts).reduce((a, b) => a + b, 0),
+          });
+        });
+        const colors = ['#02bcbb', '#8879fc', '#9c0f2e', '#ffe066', '#0c3a66', '#9e7b9b'];
+        const data = {
+          labels: ['White', 'Black', 'Hispanic', 'Asian', 'Native American', 'Other'],
+          datasets: [
+            {
+              axis: 'y',
+              label: 'All',
+              data: res.data.arrest_percentages,
+              fill: false,
+              backgroundColor: colors,
+              borderColor: colors,
+              hoverBackgroundColor: colors,
+              borderWidth: 1,
+            },
+          ],
+          isModalOpen: false,
+          tableData,
+          csvData: tableData,
+        };
+        setArrestData(data);
+      })
+      .catch((err) => console.log(err));
+  }, [year]);
+
+  const formatTooltipValue = (ctx) => `${(ctx.raw * 100).toFixed(2)}%`;
+
+  const subjectObserving = () => {
+    if (officerId) {
+      return 'by this officer';
+    }
+    if (agencyId === '-1') {
+      return 'for the entire state';
+    }
+    return 'by this department';
+  };
+
+  const getYearPhrase = () => (year && year !== 'All' ? ` in ${year}` : '');
+
+  const getBarChartModalSubHeading = (title) => `${title} ${subjectObserving()}${getYearPhrase()}`;
+
+  return (
+    <S.ChartSection>
+      <ChartHeader
+        chartTitle="Arrests By Percentage"
+        handleViewData={() => setArrestData((state) => ({ ...state, isOpen: true }))}
+      />
+      <S.ChartDescription>
+        <P>Percentage of searches that led to an arrest for a given race / ethnic group.</P>
+        <NewModal
+          tableHeader="Arrests By Percentage of Searches"
+          tableSubheader="Shows what number of searches led to an arrest for a given race / ethnic group."
+          agencyName={agencyName}
+          tableData={arrestData.tableData}
+          csvData={arrestData.csvData}
+          columns={ARRESTS_TABLE_COLUMNS}
+          tableDownloadName="Arrests_Percentage_Of_Searches"
+          isOpen={arrestData.isOpen}
+          closeModal={() => setArrestData((state) => ({ ...state, isOpen: false }))}
+        />
+      </S.ChartDescription>
+      <S.ChartSubsection showCompare={showCompare}>
+        <ChartWrapper>
+          <HorizontalBarChart
+            title="Arrests By Percentage of Searches"
+            data={arrestData}
+            displayLegend={false}
+            tooltipLabelCallback={formatTooltipValue}
+            modalConfig={{
+              tableHeader: 'Arrests By Percentage of Searches',
+              tableSubheader: getBarChartModalSubHeading(
+                'Shows what number of searches led to an arrest for a given race / ethnic group'
+              ),
+              agencyName,
+              chartTitle: getBarChartModalSubHeading('Arrests By Percentage of Searches'),
+            }}
+          />
+        </ChartWrapper>
+      </S.ChartSubsection>
+    </S.ChartSection>
+  );
+}
+
+export default PercentageOfSearches;

--- a/frontend/src/Components/Charts/Arrest/Charts/PercentageOfStops.js
+++ b/frontend/src/Components/Charts/Arrest/Charts/PercentageOfStops.js
@@ -9,8 +9,9 @@ import axios from '../../../../Services/Axios';
 import useOfficerId from '../../../../Hooks/useOfficerId';
 import { ChartWrapper } from '../Arrests.styles';
 import NewModal from '../../../NewCharts/NewModal';
+import { ARRESTS_TABLE_COLUMNS } from '../Arrests';
 
-function ArrestsByPercentage(props) {
+function PercentageOfStops(props) {
   const { agencyId, agencyName, showCompare, year } = props;
 
   const officerId = useOfficerId();
@@ -35,7 +36,7 @@ function ArrestsByPercentage(props) {
     }
 
     const urlParams = params.map((p) => `${p.param}=${p.val}`).join('&');
-    const url = `/api/agency/${agencyId}/arrests-by-percentage/?${urlParams}`;
+    const url = `/api/agency/${agencyId}/arrests-percentage-of-stops/?${urlParams}`;
     axios
       .get(url)
       .then((res) => {
@@ -140,39 +141,4 @@ function ArrestsByPercentage(props) {
   );
 }
 
-export default ArrestsByPercentage;
-
-const ARRESTS_TABLE_COLUMNS = [
-  {
-    Header: 'Year',
-    accessor: 'year', // accessor is the "key" in the data
-  },
-  {
-    Header: 'White*',
-    accessor: 'white',
-  },
-  {
-    Header: 'Black*',
-    accessor: 'black',
-  },
-  {
-    Header: 'Native American*',
-    accessor: 'native_american',
-  },
-  {
-    Header: 'Asian*',
-    accessor: 'asian',
-  },
-  {
-    Header: 'Other*',
-    accessor: 'other',
-  },
-  {
-    Header: 'Hispanic',
-    accessor: 'hispanic',
-  },
-  {
-    Header: 'Total',
-    accessor: 'total',
-  },
-];
+export default PercentageOfStops;

--- a/frontend/src/Components/Charts/ChartRoutes.js
+++ b/frontend/src/Components/Charts/ChartRoutes.js
@@ -15,6 +15,7 @@ import SearchRate from './SearchRate/SearchRate';
 import Contraband from './Contraband/Contraband';
 import UseOfForce from './UseOfForce/UseOfForce';
 import FJRoute from '../Containers/FJRoute';
+import Arrests from './Arrest/Arrests';
 
 function Charts(props) {
   const match = useRouteMatch();
@@ -62,6 +63,12 @@ function Charts(props) {
         importComponent={<UseOfForce {...props} />}
         renderLoading={() => <DataLoading />}
         renderError={() => <ChartError chartName="Use of Force" />}
+      />
+      <FJRoute
+        path={`${match.path}${slugs.ARREST_SLUG}`}
+        importComponent={<Arrests {...props} />}
+        renderLoading={() => <DataLoading />}
+        renderError={() => <ChartError chartName="Arrests" />}
       />
     </>
   );

--- a/frontend/src/Components/Sidebar/Sidebar.js
+++ b/frontend/src/Components/Sidebar/Sidebar.js
@@ -70,6 +70,13 @@ function Sidebar(props) {
         >
           Use of Force
         </SidebarLink>
+        <SidebarLink
+          data-testid="ArrestsNavLink"
+          to={buildUrl(slugs.ARREST_SLUG)}
+          showCompare={props.showCompare}
+        >
+          Arrests
+        </SidebarLink>
       </S.SidebarNav>
     </S.Sidebar>
   );

--- a/frontend/src/Routes/slugs.js
+++ b/frontend/src/Routes/slugs.js
@@ -17,3 +17,4 @@ export const SEARCHES_SLUG = '/searches';
 export const SEARCH_RATE_SLUG = '/search-rate';
 export const CONTRABAND_SLUG = '/contraband';
 export const USE_OF_FORCE_SLUG = '/use-of-force';
+export const ARREST_SLUG = '/arrests';

--- a/nc/models.py
+++ b/nc/models.py
@@ -237,6 +237,7 @@ STOP_SUMMARY_VIEW_SQL = f"""
            END) as stop_purpose_group
         , "nc_stop"."driver_arrest"
         , "nc_stop"."engage_force"
+        , (nc_search.search_id IS NOT NULL) AS driver_searched
         , "nc_search"."type" AS "search_type"
         , (CASE
             WHEN nc_contraband.contraband_id IS NULL THEN false
@@ -261,7 +262,7 @@ STOP_SUMMARY_VIEW_SQL = f"""
     LEFT OUTER JOIN "nc_contraband"
         ON ("nc_stop"."stop_id" = "nc_contraband"."stop_id")
     GROUP BY
-        2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
+        2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13
     ORDER BY "agency_id", "date" ASC;
 """  # noqa
 
@@ -280,6 +281,7 @@ class StopSummary(pg.ReadOnlyMaterializedView):
     stop_purpose_group = models.CharField(choices=StopPurposeGroup.choices, max_length=32)
     driver_arrest = models.BooleanField()
     engage_force = models.BooleanField()
+    driver_searched = models.BooleanField()
     search_type = models.PositiveSmallIntegerField(choices=SEARCH_TYPE_CHOICES)
     contraband_found = models.BooleanField()
     officer_id = models.CharField(max_length=15)

--- a/nc/models.py
+++ b/nc/models.py
@@ -235,6 +235,7 @@ STOP_SUMMARY_VIEW_SQL = f"""
                 WHEN nc_stop.purpose IN ({",".join(map(str, StopPurposeGroup.regulatory_purposes()))}) THEN 'Regulatory and Equipment'
                 ELSE 'Other'
            END) as stop_purpose_group
+        , "nc_stop"."driver_arrest"
         , "nc_stop"."engage_force"
         , "nc_search"."type" AS "search_type"
         , (CASE
@@ -260,7 +261,7 @@ STOP_SUMMARY_VIEW_SQL = f"""
     LEFT OUTER JOIN "nc_contraband"
         ON ("nc_stop"."stop_id" = "nc_contraband"."stop_id")
     GROUP BY
-        2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+        2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
     ORDER BY "agency_id", "date" ASC;
 """  # noqa
 
@@ -277,6 +278,7 @@ class StopSummary(pg.ReadOnlyMaterializedView):
     agency = models.ForeignKey("Agency", on_delete=models.DO_NOTHING)
     stop_purpose = models.PositiveSmallIntegerField(choices=StopPurpose.choices)
     stop_purpose_group = models.CharField(choices=StopPurposeGroup.choices, max_length=32)
+    driver_arrest = models.BooleanField()
     engage_force = models.BooleanField()
     search_type = models.PositiveSmallIntegerField(choices=SEARCH_TYPE_CHOICES)
     contraband_found = models.BooleanField()

--- a/nc/prime_cache.py
+++ b/nc/prime_cache.py
@@ -30,6 +30,7 @@ API_ENDPOINT_NAMES = (
     "nc:contraband-percentages-grouped-stop-purpose",
     "nc:contraband-percentages-grouped-stop-purpose-modal",
     "nc:use-of-force",
+    "nc:arrests-by-percentage",
 )
 DEFAULT_CUTOFF_SECS = 4
 

--- a/nc/prime_cache.py
+++ b/nc/prime_cache.py
@@ -30,7 +30,8 @@ API_ENDPOINT_NAMES = (
     "nc:contraband-percentages-grouped-stop-purpose",
     "nc:contraband-percentages-grouped-stop-purpose-modal",
     "nc:use-of-force",
-    "nc:arrests-by-percentage",
+    "nc:arrests-percentage-of-stops",
+    "nc:arrests-percentage-of-searches",
 )
 DEFAULT_CUTOFF_SECS = 4
 

--- a/nc/urls.py
+++ b/nc/urls.py
@@ -80,4 +80,9 @@ urlpatterns = [  # noqa
         views.AgencyUseOfForceView.as_view(),
         name="use-of-force",
     ),
+    path(
+        "api/agency/<agency_id>/arrests-by-percentage/",
+        views.AgencyArrestsByPercentageView.as_view(),
+        name="arrests-by-percentage",
+    ),
 ]

--- a/nc/urls.py
+++ b/nc/urls.py
@@ -81,8 +81,13 @@ urlpatterns = [  # noqa
         name="use-of-force",
     ),
     path(
-        "api/agency/<agency_id>/arrests-by-percentage/",
-        views.AgencyArrestsByPercentageView.as_view(),
-        name="arrests-by-percentage",
+        "api/agency/<agency_id>/arrests-percentage-of-stops/",
+        views.AgencyArrestsPercentageOfStopsView.as_view(),
+        name="arrests-percentage-of-stops",
+    ),
+    path(
+        "api/agency/<agency_id>/arrests-percentage-of-searches/",
+        views.AgencyArrestsPercentageOfSearchesView.as_view(),
+        name="arrests-percentage-of-searches",
     ),
 ]

--- a/nc/views.py
+++ b/nc/views.py
@@ -1640,3 +1640,70 @@ class AgencyUseOfForceView(APIView):
         df = pd.DataFrame(pivot_df)
         data = self.build_response(df, unique_x_range)
         return Response(data=data, status=200)
+
+
+class AgencyArrestsByPercentageView(APIView):
+    @method_decorator(cache_page(CACHE_TIMEOUT))
+    def get(self, request, agency_id):
+        year = request.GET.get("year", None)
+
+        qs = StopSummary.objects.all()
+
+        agency_id = int(agency_id)
+        if agency_id != -1:
+            qs = qs.filter(agency_id=agency_id)
+        officer = request.query_params.get("officer", None)
+        if officer:
+            qs = qs.filter(officer_id=officer)
+
+        arrest_qs = qs
+        if year:
+            arrest_qs = arrest_qs.annotate(year=ExtractYear("date")).filter(year=year)
+
+        arrest_qs = arrest_qs.values("driver_race_comb", "driver_arrest", "count")
+
+        # Build charts data
+        df = pd.DataFrame(arrest_qs)
+        columns = ["White", "Black", "Hispanic", "Asian", "Native American", "Other"]
+        percentages = [0] * len(columns)
+
+        if arrest_qs.count() > 0:
+            for i, c in enumerate(columns):
+                driver_arrest_cond = (df["driver_race_comb"] == c) & df["driver_arrest"]
+                filtered_df = df[driver_arrest_cond]
+
+                arrests_count = filtered_df["count"].sum()
+                stops_count = df[df["driver_race_comb"] == c]["count"].sum()
+                percentages[i] = arrests_count / stops_count
+
+        # Build modal table data
+        table_data_qs = (
+            qs.filter(driver_arrest=True)
+            .values("driver_race_comb")
+            .annotate(stop_count=Sum("count"))
+            .annotate(year=ExtractYear("date"))
+        )
+
+        table_data = []
+        if table_data_qs.count() > 0:
+            pivot_df = (
+                pd.DataFrame(table_data_qs)
+                .pivot(index="year", columns=["driver_race_comb"], values="stop_count")
+                .fillna(value=0)
+            )
+
+            pivot_df = pd.DataFrame(pivot_df).rename(
+                columns={
+                    "White": "white",
+                    "Black": "black",
+                    "Hispanic": "hispanic",
+                    "Asian": "asian",
+                    "Native American": "native_american",
+                    "Other": "other",
+                }
+            )
+            table_data = pivot_df.to_json(orient="table")
+
+        data = {"arrest_percentages": percentages, "table_data": table_data}
+
+        return Response(data=data, status=200)


### PR DESCRIPTION
**Branched off #279**

What's changed:
- Added chart + api views to display percentage of searches that led to arrests.

Preview:
![Screenshot 2024-03-19 at 5 40 40 PM](https://github.com/caktus/Traffic-Stops/assets/26633909/22fa4291-ddc4-445e-af24-dc42be7b900f)
