### PR TITLE
Cleanup charts for mobile screens.

### DIFF
--- a/frontend/src/Components/Charts/Arrest/Charts/CountOfStopsAndArrests.js
+++ b/frontend/src/Components/Charts/Arrest/Charts/CountOfStopsAndArrests.js
@@ -7,12 +7,12 @@ import ChartHeader from '../../ChartSections/ChartHeader';
 import HorizontalBarChart from '../../../NewCharts/HorizontalBarChart';
 import axios from '../../../../Services/Axios';
 import useOfficerId from '../../../../Hooks/useOfficerId';
-import { ChartWrapper } from '../Arrests.styles';
 import NewModal from '../../../NewCharts/NewModal';
 import { ARRESTS_TABLE_COLUMNS } from '../Arrests';
+import { ChartContainer } from '../../ChartSections/ChartsCommon.styled';
 
 function CountOfStopsAndArrests(props) {
-  const { agencyId, agencyName, showCompare, year } = props;
+  const { agencyId, agencyName, year } = props;
 
   const officerId = useOfficerId();
 
@@ -121,28 +121,26 @@ function CountOfStopsAndArrests(props) {
           closeModal={() => setArrestData((state) => ({ ...state, isOpen: false }))}
         />
       </S.ChartDescription>
-      <S.ChartSubsection showCompare={showCompare}>
-        <ChartWrapper>
-          <HorizontalBarChart
-            title="Stop Counts With/Without Arrests"
-            data={arrestData}
-            pinMaxValue={false}
-            xStacked
-            yStacked
-            tickStyle={null}
-            stepSize={50000}
-            tooltipLabelCallback={formatTooltipValue}
-            modalConfig={{
-              tableHeader: 'Stop Counts With/Without Arrests',
-              tableSubheader: getBarChartModalSubHeading(
-                'Shows what number of stops led to an arrest for a given race / ethnic group'
-              ),
-              agencyName,
-              chartTitle: getBarChartModalSubHeading('Stop Counts With/Without Arrests'),
-            }}
-          />
-        </ChartWrapper>
-      </S.ChartSubsection>
+      <ChartContainer>
+        <HorizontalBarChart
+          title="Stop Counts With/Without Arrests"
+          data={arrestData}
+          pinMaxValue={false}
+          xStacked
+          yStacked
+          tickStyle={null}
+          stepSize={50000}
+          tooltipLabelCallback={formatTooltipValue}
+          modalConfig={{
+            tableHeader: 'Stop Counts With/Without Arrests',
+            tableSubheader: getBarChartModalSubHeading(
+              'Shows what number of stops led to an arrest for a given race / ethnic group'
+            ),
+            agencyName,
+            chartTitle: getBarChartModalSubHeading('Stop Counts With/Without Arrests'),
+          }}
+        />
+      </ChartContainer>
     </S.ChartSection>
   );
 }

--- a/frontend/src/Components/Charts/Arrest/Charts/PercentageOfSearches.js
+++ b/frontend/src/Components/Charts/Arrest/Charts/PercentageOfSearches.js
@@ -7,12 +7,12 @@ import ChartHeader from '../../ChartSections/ChartHeader';
 import HorizontalBarChart from '../../../NewCharts/HorizontalBarChart';
 import axios from '../../../../Services/Axios';
 import useOfficerId from '../../../../Hooks/useOfficerId';
-import { ChartWrapper } from '../Arrests.styles';
 import NewModal from '../../../NewCharts/NewModal';
 import { ARRESTS_TABLE_COLUMNS } from '../Arrests';
+import { ChartContainer } from '../../ChartSections/ChartsCommon.styled';
 
 function PercentageOfSearches(props) {
-  const { agencyId, agencyName, showCompare, year } = props;
+  const { agencyId, agencyName, year } = props;
 
   const officerId = useOfficerId();
 
@@ -119,24 +119,22 @@ function PercentageOfSearches(props) {
           closeModal={() => setArrestData((state) => ({ ...state, isOpen: false }))}
         />
       </S.ChartDescription>
-      <S.ChartSubsection showCompare={showCompare}>
-        <ChartWrapper>
-          <HorizontalBarChart
-            title="Arrests By Percentage of Searches"
-            data={arrestData}
-            displayLegend={false}
-            tooltipLabelCallback={formatTooltipValue}
-            modalConfig={{
-              tableHeader: 'Arrests By Percentage of Searches',
-              tableSubheader: getBarChartModalSubHeading(
-                'Shows what number of searches led to an arrest for a given race / ethnic group'
-              ),
-              agencyName,
-              chartTitle: getBarChartModalSubHeading('Arrests By Percentage of Searches'),
-            }}
-          />
-        </ChartWrapper>
-      </S.ChartSubsection>
+      <ChartContainer>
+        <HorizontalBarChart
+          title="Arrests By Percentage of Searches"
+          data={arrestData}
+          displayLegend={false}
+          tooltipLabelCallback={formatTooltipValue}
+          modalConfig={{
+            tableHeader: 'Arrests By Percentage of Searches',
+            tableSubheader: getBarChartModalSubHeading(
+              'Shows what number of searches led to an arrest for a given race / ethnic group'
+            ),
+            agencyName,
+            chartTitle: getBarChartModalSubHeading('Arrests By Percentage of Searches'),
+          }}
+        />
+      </ChartContainer>
     </S.ChartSection>
   );
 }

--- a/frontend/src/Components/Charts/Arrest/Charts/PercentageOfSearchesForPurposeGroup.js
+++ b/frontend/src/Components/Charts/Arrest/Charts/PercentageOfSearchesForPurposeGroup.js
@@ -7,12 +7,12 @@ import ChartHeader from '../../ChartSections/ChartHeader';
 import HorizontalBarChart from '../../../NewCharts/HorizontalBarChart';
 import axios from '../../../../Services/Axios';
 import useOfficerId from '../../../../Hooks/useOfficerId';
-import { ChartWrapper } from '../Arrests.styles';
 import NewModal from '../../../NewCharts/NewModal';
 import { ARRESTS_TABLE_COLUMNS } from '../Arrests';
+import { ChartContainer } from '../../ChartSections/ChartsCommon.styled';
 
 function PercentageOfSearchesForStopPurposeGroup(props) {
-  const { agencyId, agencyName, showCompare, year } = props;
+  const { agencyId, agencyName, year } = props;
 
   const officerId = useOfficerId();
 
@@ -124,26 +124,24 @@ function PercentageOfSearchesForStopPurposeGroup(props) {
           closeModal={() => setArrestData((state) => ({ ...state, isOpen: false }))}
         />
       </S.ChartDescription>
-      <S.ChartSubsection showCompare={showCompare}>
-        <ChartWrapper>
-          <HorizontalBarChart
-            title="Percentage of Searches With Arrests Per Stop Purpose Group"
-            data={arrestData}
-            displayLegend={false}
-            tooltipLabelCallback={formatTooltipValue}
-            modalConfig={{
-              tableHeader: 'Percentage of Searches With Arrests Per Stop Purpose Group',
-              tableSubheader: getBarChartModalSubHeading(
-                'Shows what percentage of searches led to an arrest for a given stop purpose group.'
-              ),
-              agencyName,
-              chartTitle: getBarChartModalSubHeading(
-                'Percentage of Searches With Arrests Per Stop Purpose Group'
-              ),
-            }}
-          />
-        </ChartWrapper>
-      </S.ChartSubsection>
+      <ChartContainer>
+        <HorizontalBarChart
+          title="Percentage of Searches With Arrests Per Stop Purpose Group"
+          data={arrestData}
+          displayLegend={false}
+          tooltipLabelCallback={formatTooltipValue}
+          modalConfig={{
+            tableHeader: 'Percentage of Searches With Arrests Per Stop Purpose Group',
+            tableSubheader: getBarChartModalSubHeading(
+              'Shows what percentage of searches led to an arrest for a given stop purpose group.'
+            ),
+            agencyName,
+            chartTitle: getBarChartModalSubHeading(
+              'Percentage of Searches With Arrests Per Stop Purpose Group'
+            ),
+          }}
+        />
+      </ChartContainer>
     </S.ChartSection>
   );
 }

--- a/frontend/src/Components/Charts/Arrest/Charts/PercentageOfSearchesPerStopPurpose.js
+++ b/frontend/src/Components/Charts/Arrest/Charts/PercentageOfSearchesPerStopPurpose.js
@@ -7,12 +7,12 @@ import ChartHeader from '../../ChartSections/ChartHeader';
 import HorizontalBarChart from '../../../NewCharts/HorizontalBarChart';
 import axios from '../../../../Services/Axios';
 import useOfficerId from '../../../../Hooks/useOfficerId';
-import { ChartWrapper } from '../Arrests.styles';
 import NewModal from '../../../NewCharts/NewModal';
 import { ARRESTS_TABLE_COLUMNS } from '../Arrests';
+import { ChartContainer } from '../../ChartSections/ChartsCommon.styled';
 
 function PercentageOfStopsForStopPurpose(props) {
-  const { agencyId, agencyName, showCompare, year } = props;
+  const { agencyId, agencyName, year } = props;
 
   const officerId = useOfficerId();
 
@@ -119,27 +119,25 @@ function PercentageOfStopsForStopPurpose(props) {
           closeModal={() => setArrestData((state) => ({ ...state, isOpen: false }))}
         />
       </S.ChartDescription>
-      <S.ChartSubsection showCompare={showCompare}>
-        <ChartWrapper>
-          <HorizontalBarChart
-            title="Percentage of Searches With Arrests Per Stop Purpose"
-            data={arrestData}
-            displayLegend={false}
-            tooltipLabelCallback={formatTooltipValue}
-            pinMaxValue={false}
-            modalConfig={{
-              tableHeader: 'Percentage of Searches With Arrests Per Stop Purpose',
-              tableSubheader: getBarChartModalSubHeading(
-                'Shows what percentage of searches led to an arrest for a given stop purpose.'
-              ),
-              agencyName,
-              chartTitle: getBarChartModalSubHeading(
-                'Percentage of Searches With Arrests Per Stop Purpose'
-              ),
-            }}
-          />
-        </ChartWrapper>
-      </S.ChartSubsection>
+      <ChartContainer>
+        <HorizontalBarChart
+          title="Percentage of Searches With Arrests Per Stop Purpose"
+          data={arrestData}
+          displayLegend={false}
+          tooltipLabelCallback={formatTooltipValue}
+          pinMaxValue={false}
+          modalConfig={{
+            tableHeader: 'Percentage of Searches With Arrests Per Stop Purpose',
+            tableSubheader: getBarChartModalSubHeading(
+              'Shows what percentage of searches led to an arrest for a given stop purpose.'
+            ),
+            agencyName,
+            chartTitle: getBarChartModalSubHeading(
+              'Percentage of Searches With Arrests Per Stop Purpose'
+            ),
+          }}
+        />
+      </ChartContainer>
     </S.ChartSection>
   );
 }

--- a/frontend/src/Components/Charts/Arrest/Charts/PercentageOfStops.js
+++ b/frontend/src/Components/Charts/Arrest/Charts/PercentageOfStops.js
@@ -7,12 +7,12 @@ import ChartHeader from '../../ChartSections/ChartHeader';
 import HorizontalBarChart from '../../../NewCharts/HorizontalBarChart';
 import axios from '../../../../Services/Axios';
 import useOfficerId from '../../../../Hooks/useOfficerId';
-import { ChartWrapper } from '../Arrests.styles';
 import NewModal from '../../../NewCharts/NewModal';
 import { ARRESTS_TABLE_COLUMNS } from '../Arrests';
+import { ChartContainer } from '../../ChartSections/ChartsCommon.styled';
 
 function PercentageOfStops(props) {
-  const { agencyId, agencyName, showCompare, year } = props;
+  const { agencyId, agencyName, year } = props;
 
   const officerId = useOfficerId();
 
@@ -119,24 +119,22 @@ function PercentageOfStops(props) {
           closeModal={() => setArrestData((state) => ({ ...state, isOpen: false }))}
         />
       </S.ChartDescription>
-      <S.ChartSubsection showCompare={showCompare}>
-        <ChartWrapper>
-          <HorizontalBarChart
-            title="Arrests By Percentage"
-            data={arrestData}
-            displayLegend={false}
-            tooltipLabelCallback={formatTooltipValue}
-            modalConfig={{
-              tableHeader: 'Arrests By Percentage',
-              tableSubheader: getBarChartModalSubHeading(
-                'Shows what percentage of stops led to an arrest for a given race / ethnic group'
-              ),
-              agencyName,
-              chartTitle: getBarChartModalSubHeading('Arrests By Percentage'),
-            }}
-          />
-        </ChartWrapper>
-      </S.ChartSubsection>
+      <ChartContainer>
+        <HorizontalBarChart
+          title="Arrests By Percentage"
+          data={arrestData}
+          displayLegend={false}
+          tooltipLabelCallback={formatTooltipValue}
+          modalConfig={{
+            tableHeader: 'Arrests By Percentage',
+            tableSubheader: getBarChartModalSubHeading(
+              'Shows what percentage of stops led to an arrest for a given race / ethnic group'
+            ),
+            agencyName,
+            chartTitle: getBarChartModalSubHeading('Arrests By Percentage'),
+          }}
+        />
+      </ChartContainer>
     </S.ChartSection>
   );
 }

--- a/frontend/src/Components/Charts/Arrest/Charts/PercentageOfStopsForPurposeGroup.js
+++ b/frontend/src/Components/Charts/Arrest/Charts/PercentageOfStopsForPurposeGroup.js
@@ -7,12 +7,12 @@ import ChartHeader from '../../ChartSections/ChartHeader';
 import HorizontalBarChart from '../../../NewCharts/HorizontalBarChart';
 import axios from '../../../../Services/Axios';
 import useOfficerId from '../../../../Hooks/useOfficerId';
-import { ChartWrapper } from '../Arrests.styles';
 import NewModal from '../../../NewCharts/NewModal';
 import { ARRESTS_TABLE_COLUMNS } from '../Arrests';
+import { ChartContainer } from '../../ChartSections/ChartsCommon.styled';
 
 function PercentageOfStopsForStopPurposeGroup(props) {
-  const { agencyId, agencyName, showCompare, year } = props;
+  const { agencyId, agencyName, year } = props;
 
   const officerId = useOfficerId();
 
@@ -124,26 +124,24 @@ function PercentageOfStopsForStopPurposeGroup(props) {
           closeModal={() => setArrestData((state) => ({ ...state, isOpen: false }))}
         />
       </S.ChartDescription>
-      <S.ChartSubsection showCompare={showCompare}>
-        <ChartWrapper>
-          <HorizontalBarChart
-            title="Percentage of Stops With Arrests Per Stop Purpose Group"
-            data={arrestData}
-            displayLegend={false}
-            tooltipLabelCallback={formatTooltipValue}
-            modalConfig={{
-              tableHeader: 'Percentage of Stops With Arrests Per Stop Purpose Group',
-              tableSubheader: getBarChartModalSubHeading(
-                'Shows what percentage of stops led to an arrest for a given stop purpose group.'
-              ),
-              agencyName,
-              chartTitle: getBarChartModalSubHeading(
-                'Percentage of Stops With Arrests Per Stop Purpose Group'
-              ),
-            }}
-          />
-        </ChartWrapper>
-      </S.ChartSubsection>
+      <ChartContainer>
+        <HorizontalBarChart
+          title="Percentage of Stops With Arrests Per Stop Purpose Group"
+          data={arrestData}
+          displayLegend={false}
+          tooltipLabelCallback={formatTooltipValue}
+          modalConfig={{
+            tableHeader: 'Percentage of Stops With Arrests Per Stop Purpose Group',
+            tableSubheader: getBarChartModalSubHeading(
+              'Shows what percentage of stops led to an arrest for a given stop purpose group.'
+            ),
+            agencyName,
+            chartTitle: getBarChartModalSubHeading(
+              'Percentage of Stops With Arrests Per Stop Purpose Group'
+            ),
+          }}
+        />
+      </ChartContainer>
     </S.ChartSection>
   );
 }

--- a/frontend/src/Components/Charts/Arrest/Charts/PercentageOfStopsPerContrabandType.js
+++ b/frontend/src/Components/Charts/Arrest/Charts/PercentageOfStopsPerContrabandType.js
@@ -7,12 +7,12 @@ import ChartHeader from '../../ChartSections/ChartHeader';
 import HorizontalBarChart from '../../../NewCharts/HorizontalBarChart';
 import axios from '../../../../Services/Axios';
 import useOfficerId from '../../../../Hooks/useOfficerId';
-import { ChartWrapper } from '../Arrests.styles';
 import NewModal from '../../../NewCharts/NewModal';
 import { ARRESTS_TABLE_COLUMNS } from '../Arrests';
+import { ChartContainer } from '../../ChartSections/ChartsCommon.styled';
 
 function PercentageOfStopsPerContrabandType(props) {
-  const { agencyId, agencyName, showCompare, year } = props;
+  const { agencyId, agencyName, year } = props;
 
   const officerId = useOfficerId();
 
@@ -120,26 +120,24 @@ function PercentageOfStopsPerContrabandType(props) {
           closeModal={() => setArrestData((state) => ({ ...state, isOpen: false }))}
         />
       </S.ChartDescription>
-      <S.ChartSubsection showCompare={showCompare}>
-        <ChartWrapper>
-          <HorizontalBarChart
-            title="Percentage of Stops With Arrests Per Contraband Type"
-            data={arrestData}
-            displayLegend={false}
-            tooltipLabelCallback={formatTooltipValue}
-            modalConfig={{
-              tableHeader: 'Percentage of Stops With Arrests Per Contraband Type',
-              tableSubheader: getBarChartModalSubHeading(
-                'Shows what percentage of stops led to an arrest for a given contraband type'
-              ),
-              agencyName,
-              chartTitle: getBarChartModalSubHeading(
-                'Percentage of Stops With Arrests Per Contraband Type'
-              ),
-            }}
-          />
-        </ChartWrapper>
-      </S.ChartSubsection>
+      <ChartContainer>
+        <HorizontalBarChart
+          title="Percentage of Stops With Arrests Per Contraband Type"
+          data={arrestData}
+          displayLegend={false}
+          tooltipLabelCallback={formatTooltipValue}
+          modalConfig={{
+            tableHeader: 'Percentage of Stops With Arrests Per Contraband Type',
+            tableSubheader: getBarChartModalSubHeading(
+              'Shows what percentage of stops led to an arrest for a given contraband type'
+            ),
+            agencyName,
+            chartTitle: getBarChartModalSubHeading(
+              'Percentage of Stops With Arrests Per Contraband Type'
+            ),
+          }}
+        />
+      </ChartContainer>
     </S.ChartSection>
   );
 }

--- a/frontend/src/Components/Charts/Arrest/Charts/PercentageOfStopsPerStopPurpose.js
+++ b/frontend/src/Components/Charts/Arrest/Charts/PercentageOfStopsPerStopPurpose.js
@@ -7,12 +7,12 @@ import ChartHeader from '../../ChartSections/ChartHeader';
 import HorizontalBarChart from '../../../NewCharts/HorizontalBarChart';
 import axios from '../../../../Services/Axios';
 import useOfficerId from '../../../../Hooks/useOfficerId';
-import { ChartWrapper } from '../Arrests.styles';
 import NewModal from '../../../NewCharts/NewModal';
 import { ARRESTS_TABLE_COLUMNS } from '../Arrests';
+import { ChartContainer } from '../../ChartSections/ChartsCommon.styled';
 
 function PercentageOfStopsForStopPurpose(props) {
-  const { agencyId, agencyName, showCompare, year } = props;
+  const { agencyId, agencyName, year } = props;
 
   const officerId = useOfficerId();
 
@@ -119,26 +119,24 @@ function PercentageOfStopsForStopPurpose(props) {
           closeModal={() => setArrestData((state) => ({ ...state, isOpen: false }))}
         />
       </S.ChartDescription>
-      <S.ChartSubsection showCompare={showCompare}>
-        <ChartWrapper>
-          <HorizontalBarChart
-            title="Percentage of Stops With Arrests Per Stop Purpose"
-            data={arrestData}
-            displayLegend={false}
-            tooltipLabelCallback={formatTooltipValue}
-            modalConfig={{
-              tableHeader: 'Percentage of Stops With Arrests Per Stop Purpose',
-              tableSubheader: getBarChartModalSubHeading(
-                'Shows what percentage of stops led to an arrest for a given stop purpose.'
-              ),
-              agencyName,
-              chartTitle: getBarChartModalSubHeading(
-                'Percentage of Stops With Arrests Per Stop Purpose'
-              ),
-            }}
-          />
-        </ChartWrapper>
-      </S.ChartSubsection>
+      <ChartContainer>
+        <HorizontalBarChart
+          title="Percentage of Stops With Arrests Per Stop Purpose"
+          data={arrestData}
+          displayLegend={false}
+          tooltipLabelCallback={formatTooltipValue}
+          modalConfig={{
+            tableHeader: 'Percentage of Stops With Arrests Per Stop Purpose',
+            tableSubheader: getBarChartModalSubHeading(
+              'Shows what percentage of stops led to an arrest for a given stop purpose.'
+            ),
+            agencyName,
+            chartTitle: getBarChartModalSubHeading(
+              'Percentage of Stops With Arrests Per Stop Purpose'
+            ),
+          }}
+        />
+      </ChartContainer>
     </S.ChartSection>
   );
 }

--- a/frontend/src/Components/Charts/ChartSections/ChartsCommon.styled.js
+++ b/frontend/src/Components/Charts/ChartSections/ChartsCommon.styled.js
@@ -35,7 +35,6 @@ export const ChartWarning = styled.div`
 export const ChartSubsection = styled.div`
   display: flex;
   flex-direction: ${(props) => (props.showCompare ? 'column' : 'row')};
-  flex: 1;
 
   @media (${smallerThanDesktop}) {
     flex-direction: column;
@@ -65,9 +64,6 @@ export const PieSection = styled.div`
   display: flex;
   flex-direction: column;
   align-items: ${(props) => (props.alignItems ? props.alignItems : 'center')};
-  width: ${(props) => (props.zoomed ? '90%' : '33%')};
-  margin: 0 auto;
-  height: auto;
 
   @media (${smallerThanDesktop}) {
     flex-direction: row;
@@ -146,31 +142,8 @@ export const LegendBeside = styled.div`
   }
 `;
 
-export const NoBaseSearches = styled.div`
-  flex: 1;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  height: 100%;
-  padding: 2em;
-  text-align: center;
-`;
-
-export const NoBaseLink = styled.span`
-  cursor: pointer;
-  color: ${(p) => p.theme.colors.primaryDark};
-`;
-
-export const LegendSection = styled.div`
-  margin-top: 2em;
-  display: flex;
-  flex-direction: column;
-  align-items: start;
-  width: 100%;
-  flex: 0;
-
-  @media (${smallerThanDesktop}) {
-    width: 100%;
-  }
+export const ChartContainer = styled.div`
+  min-height: 400px;
+  height: 600px;
+  ${(props) => props.override};
 `;

--- a/frontend/src/Components/Charts/Contraband/Contraband.js
+++ b/frontend/src/Components/Charts/Contraband/Contraband.js
@@ -1,9 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import ContrabandStyled, {
-  BarContainer,
-  ChartWrapper,
-  HorizontalBarWrapper,
-} from './Contraband.styled';
+import ContrabandStyled, { BarContainer, HorizontalBarWrapper } from './Contraband.styled';
 import * as S from '../ChartSections/ChartsCommon.styled';
 
 // Util
@@ -28,11 +24,12 @@ import cloneDeep from 'lodash.clonedeep';
 import Checkbox from '../../Elements/Inputs/Checkbox';
 import toTitleCase from '../../../util/toTitleCase';
 import useOfficerId from '../../../Hooks/useOfficerId';
+import { ChartContainer } from '../ChartSections/ChartsCommon.styled';
 
 const STOP_PURPOSE_TYPES = ['Safety Violation', 'Regulatory and Equipment', 'Other'];
 
 function Contraband(props) {
-  const { agencyId, showCompare } = props;
+  const { agencyId } = props;
 
   const officerId = useOfficerId();
   const [chartState] = useDataset(agencyId, CONTRABAND_HIT_RATE);
@@ -586,24 +583,22 @@ function Contraband(props) {
             closeModal={() => setContrabandData((state) => ({ ...state, isOpen: false }))}
           />
         </S.ChartDescription>
-        <S.ChartSubsection showCompare={showCompare}>
-          <ChartWrapper>
-            <HorizontalBarChart
-              title='Contraband "Hit Rate"'
-              data={contrabandData}
-              displayLegend={false}
-              tooltipLabelCallback={formatTooltipValue}
-              modalConfig={{
-                tableHeader: 'Contraband "Hit Rate"',
-                tableSubheader: getBarChartModalSubHeading(
-                  'Shows what percentage of searches led to the discovery of illegal items by race/ethnicity'
-                ),
-                agencyName: chartState.data[AGENCY_DETAILS].name,
-                chartTitle: getBarChartModalHeading('Contraband "Hit Rate"'),
-              }}
-            />
-          </ChartWrapper>
-        </S.ChartSubsection>
+        <ChartContainer>
+          <HorizontalBarChart
+            title='Contraband "Hit Rate"'
+            data={contrabandData}
+            displayLegend={false}
+            tooltipLabelCallback={formatTooltipValue}
+            modalConfig={{
+              tableHeader: 'Contraband "Hit Rate"',
+              tableSubheader: getBarChartModalSubHeading(
+                'Shows what percentage of searches led to the discovery of illegal items by race/ethnicity'
+              ),
+              agencyName: chartState.data[AGENCY_DETAILS].name,
+              chartTitle: getBarChartModalHeading('Contraband "Hit Rate"'),
+            }}
+          />
+        </ChartContainer>
       </S.ChartSection>
       <S.ChartSection id="hit_rate_by_stop_purpose">
         <ChartHeader
@@ -639,27 +634,23 @@ function Contraband(props) {
             options={STOP_PURPOSE_TYPES}
           />
         </NewModal>
-        <S.ChartSubsection showCompare={showCompare}>
-          <ChartWrapper>
-            <HorizontalBarChart
-              title='Contraband "Hit Rate" Grouped By Stop Purpose'
-              data={contrabandStopPurposeData}
-              tooltipTitleCallback={formatTooltipLabel}
-              tooltipLabelCallback={formatTooltipValue}
-              displayStopPurposeTooltips
-              modalConfig={{
-                tableHeader: 'Contraband "Hit Rate" Grouped By Stop Purpose',
-                tableSubheader: getBarChartModalSubHeading(
-                  'Shows what number of searches led to the discovery of illegal items by race/ethnicity and original stop purpose'
-                ),
-                agencyName: chartState.data[AGENCY_DETAILS].name,
-                chartTitle: getBarChartModalHeading(
-                  'Contraband "Hit Rate" Grouped By Stop Purpose'
-                ),
-              }}
-            />
-          </ChartWrapper>
-        </S.ChartSubsection>
+        <ChartContainer>
+          <HorizontalBarChart
+            title='Contraband "Hit Rate" Grouped By Stop Purpose'
+            data={contrabandStopPurposeData}
+            tooltipTitleCallback={formatTooltipLabel}
+            tooltipLabelCallback={formatTooltipValue}
+            displayStopPurposeTooltips
+            modalConfig={{
+              tableHeader: 'Contraband "Hit Rate" Grouped By Stop Purpose',
+              tableSubheader: getBarChartModalSubHeading(
+                'Shows what number of searches led to the discovery of illegal items by race/ethnicity and original stop purpose'
+              ),
+              agencyName: chartState.data[AGENCY_DETAILS].name,
+              chartTitle: getBarChartModalHeading('Contraband "Hit Rate" Grouped By Stop Purpose'),
+            }}
+          />
+        </ChartContainer>
       </S.ChartSection>
       <S.ChartSection id="hit_rate_by_type">
         <ChartHeader
@@ -683,25 +674,22 @@ function Contraband(props) {
             closeModal={() => setContrabandTypesData((state) => ({ ...state, isOpen: false }))}
           />
         </S.ChartDescription>
-        <S.ChartSubsection showCompare={showCompare}>
-          <ChartWrapper>
-            <HorizontalBarChart
-              title='Contraband "Hit Rate" by type'
-              data={contrabandTypesData}
-              displayLegend={false}
-              tooltipLabelCallback={formatTooltipValue}
-              modalConfig={{
-                tableHeader: 'Contraband "Hit Rate" by type',
-                tableSubheader: getBarChartModalSubHeading(
-                  'Shows what number of searches discovered specific types of illegal items'
-                ),
-                agencyName: chartState.data[AGENCY_DETAILS].name,
-                chartTitle: getBarChartModalHeading('Contraband "Hit Rate" by type'),
-              }}
-            />
-          </ChartWrapper>
-          <S.LegendSection />
-        </S.ChartSubsection>
+        <ChartContainer>
+          <HorizontalBarChart
+            title='Contraband "Hit Rate" by type'
+            data={contrabandTypesData}
+            displayLegend={false}
+            tooltipLabelCallback={formatTooltipValue}
+            modalConfig={{
+              tableHeader: 'Contraband "Hit Rate" by type',
+              tableSubheader: getBarChartModalSubHeading(
+                'Shows what number of searches discovered specific types of illegal items'
+              ),
+              agencyName: chartState.data[AGENCY_DETAILS].name,
+              chartTitle: getBarChartModalHeading('Contraband "Hit Rate" by type'),
+            }}
+          />
+        </ChartContainer>
       </S.ChartSection>
       <S.ChartSection marginTop={5} id="hit_rate_by_type_and_stop_purpose">
         <ChartHeader

--- a/frontend/src/Components/Charts/Contraband/Contraband.styled.js
+++ b/frontend/src/Components/Charts/Contraband/Contraband.styled.js
@@ -4,11 +4,6 @@ import { smallerThanDesktop, smallerThanTabletLandscape } from '../../../styles/
 
 export default styled(ChartPageBase)``;
 
-export const ChartWrapper = styled.div`
-  width: 100%;
-  height: auto;
-`;
-
 export const HorizontalBarWrapper = styled.div`
   display: flex;
   flex-direction: row;

--- a/frontend/src/Components/Charts/SearchRate/SearchRate.js
+++ b/frontend/src/Components/Charts/SearchRate/SearchRate.js
@@ -19,9 +19,10 @@ import ChartHeader from '../ChartSections/ChartHeader';
 import DataSubsetPicker from '../ChartSections/DataSubsetPicker/DataSubsetPicker';
 import axios from '../../../Services/Axios';
 import HorizontalBarChart from '../../NewCharts/HorizontalBarChart';
+import { ChartContainer } from '../ChartSections/ChartsCommon.styled';
 
 function SearchRate(props) {
-  const { agencyId, showCompare } = props;
+  const { agencyId } = props;
   const officerId = useOfficerId();
 
   const [chartState] = useDataset(agencyId, LIKELIHOOD_OF_SEARCH);
@@ -112,38 +113,29 @@ function SearchRate(props) {
             incidents. Use “View Data” to see the numbers underlying the calculations.
           </P>
         </S.ChartDescription>
-        <S.ChartSubsection showCompare={showCompare}>
-          <S.LineWrapper>
-            <div style={{ height: '200vh' }}>
-              <HorizontalBarChart
-                title="Likelihood of Search"
-                data={searchRateData}
-                maintainAspectRatio={false}
-                tooltipTitleCallback={formatTooltipLabel}
-                tooltipLabelCallback={formatTooltipValue}
-                legendPosition="bottom"
-                pinMaxValue={false}
-                modalConfig={{
-                  tableHeader: 'Likelihood of Search',
-                  tableSubheader: getBarChartModalSubHeading(),
-                  agencyName: chartState.data[AGENCY_DETAILS].name,
-                  chartTitle: getBarChartModalHeading('Likelihood of Search'),
-                }}
-              />
-            </div>
-          </S.LineWrapper>
-          <S.LegendBelow>
-            <S.Spacing>
-              <DataSubsetPicker
-                label="Year"
-                value={year}
-                onChange={handleYearSelected}
-                options={[YEARS_DEFAULT].concat(chartState.yearRange)}
-                dropUp={!!showCompare}
-              />
-            </S.Spacing>
-          </S.LegendBelow>
-        </S.ChartSubsection>
+        <DataSubsetPicker
+          label="Year"
+          value={year}
+          onChange={handleYearSelected}
+          options={[YEARS_DEFAULT].concat(chartState.yearRange)}
+        />
+        <ChartContainer override={{ height: '200vh' }}>
+          <HorizontalBarChart
+            title="Likelihood of Search"
+            data={searchRateData}
+            maintainAspectRatio={false}
+            tooltipTitleCallback={formatTooltipLabel}
+            tooltipLabelCallback={formatTooltipValue}
+            legendPosition="bottom"
+            pinMaxValue={false}
+            modalConfig={{
+              tableHeader: 'Likelihood of Search',
+              tableSubheader: getBarChartModalSubHeading(),
+              agencyName: chartState.data[AGENCY_DETAILS].name,
+              chartTitle: getBarChartModalHeading('Likelihood of Search'),
+            }}
+          />
+        </ChartContainer>
       </S.ChartSection>
     </SearchRateStyled>
   );

--- a/frontend/src/Components/Charts/Searches/Searches.js
+++ b/frontend/src/Components/Charts/Searches/Searches.js
@@ -25,9 +25,9 @@ import ChartHeader from '../ChartSections/ChartHeader';
 import DataSubsetPicker from '../ChartSections/DataSubsetPicker/DataSubsetPicker';
 import useOfficerId from '../../../Hooks/useOfficerId';
 import displayDefinition from '../../../util/displayDefinition';
-import { LineWrapper, StopGroupsContainer } from '../TrafficStops/TrafficStops.styled';
 import LineChart from '../../NewCharts/LineChart';
 import axios from '../../../Services/Axios';
+import { ChartContainer } from '../ChartSections/ChartsCommon.styled';
 
 function Searches(props) {
   const { agencyId } = props;
@@ -178,29 +178,25 @@ function Searches(props) {
           }}
         />
         <P>Shows the percent of stops that led to searches, broken down by race/ethnicity.</P>
-        <S.ChartSubsection showCompare={props.showCompare}>
-          <LineWrapper visible>
-            <StopGroupsContainer>
-              <LineChart
-                data={searchPercentageData}
-                title="Searches By Percentage"
-                maintainAspectRatio={false}
-                showLegendOnBottom
-                yScaleFormat="percent"
-                tooltipTitleCallback={formatTooltipLabel}
-                tooltipLabelCallback={formatTooltipValue}
-                modalConfig={{
-                  tableHeader: 'Searches By Percentage',
-                  tableSubheader: getLineChartModalSubHeading(
-                    'Shows the percent of stops that led to searches, broken down by race/ethnicity'
-                  ),
-                  agencyName: chartState.data[AGENCY_DETAILS].name,
-                  chartTitle: getLineChartModalHeading('Searches By Percentage', false),
-                }}
-              />
-            </StopGroupsContainer>
-          </LineWrapper>
-        </S.ChartSubsection>
+        <ChartContainer>
+          <LineChart
+            data={searchPercentageData}
+            title="Searches By Percentage"
+            maintainAspectRatio={false}
+            showLegendOnBottom
+            yScaleFormat="percent"
+            tooltipTitleCallback={formatTooltipLabel}
+            tooltipLabelCallback={formatTooltipValue}
+            modalConfig={{
+              tableHeader: 'Searches By Percentage',
+              tableSubheader: getLineChartModalSubHeading(
+                'Shows the percent of stops that led to searches, broken down by race/ethnicity'
+              ),
+              agencyName: chartState.data[AGENCY_DETAILS].name,
+              chartTitle: getLineChartModalHeading('Searches By Percentage', false),
+            }}
+          />
+        </ChartContainer>
       </S.ChartSection>
       {/* Searches by Count */}
       <S.ChartSection id="searches_by_count">
@@ -215,35 +211,37 @@ function Searches(props) {
           Shows the number of searches performed {subjectObserving()}, broken down by search type
           and race / ethnicity.
         </P>
-        <S.ChartSubsection showCompare={props.showCompare}>
-          <LineWrapper visible>
-            <StopGroupsContainer>
-              <LineChart
-                data={searchCountData}
-                title="Searches By Count"
-                maintainAspectRatio={false}
-                showLegendOnBottom
-                modalConfig={{
-                  tableHeader: 'Searches By Count',
-                  tableSubheader: getLineChartModalSubHeading(
-                    `Shows the number of searches performed ${subjectObserving()}, broken down by search type and race / ethnicity`
-                  ),
-                  agencyName: chartState.data[AGENCY_DETAILS].name,
-                  chartTitle: getLineChartModalHeading('Searches By Count', true),
-                }}
-              />
-            </StopGroupsContainer>
-          </LineWrapper>
-          <S.LegendBeside>
-            <DataSubsetPicker
-              label="Search Type"
-              value={searchType}
-              onChange={handleStopPurposeSelect}
-              options={[SEARCH_TYPE_DEFAULT].concat(SEARCH_TYPES)}
-            />
-            <p style={{ marginTop: '10px' }}>{displayDefinition(searchType)}</p>
-          </S.LegendBeside>
-        </S.ChartSubsection>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '10px',
+          }}
+        >
+          <DataSubsetPicker
+            label="Search Type"
+            value={searchType}
+            onChange={handleStopPurposeSelect}
+            options={[SEARCH_TYPE_DEFAULT].concat(SEARCH_TYPES)}
+          />
+          <p>{displayDefinition(searchType)}</p>
+        </div>
+        <ChartContainer>
+          <LineChart
+            data={searchCountData}
+            title="Searches By Count"
+            maintainAspectRatio={false}
+            showLegendOnBottom
+            modalConfig={{
+              tableHeader: 'Searches By Count',
+              tableSubheader: getLineChartModalSubHeading(
+                `Shows the number of searches performed ${subjectObserving()}, broken down by search type and race / ethnicity`
+              ),
+              agencyName: chartState.data[AGENCY_DETAILS].name,
+              chartTitle: getLineChartModalHeading('Searches By Count', true),
+            }}
+          />
+        </ChartContainer>
       </S.ChartSection>
     </SearchesStyled>
   );

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.js
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import TrafficStopsStyled, {
   GroupedStopsContainer,
+  LineChartWithPieContainer,
   LineWrapper,
+  PieContainer,
   PieStopsContainer,
   PieWrapper,
   StopGroupsContainer,
@@ -48,9 +50,10 @@ import Switch from 'react-switch';
 import Checkbox from '../../Elements/Inputs/Checkbox';
 import { pieChartConfig, pieChartLabels, pieColors } from '../../../util/setChartColors';
 import VerticalBarChart from '../../NewCharts/VerticalBarChart';
+import { ChartContainer } from '../ChartSections/ChartsCommon.styled';
 
 function TrafficStops(props) {
-  const { agencyId } = props;
+  const { agencyId, showCompare } = props;
 
   const theme = useTheme();
   const officerId = useOfficerId();
@@ -713,11 +716,12 @@ function TrafficStops(props) {
           </P>
           <P>{getChartDetailedBreakdown()}</P>
         </S.ChartDescription>
-        <S.ChartSubsection showCompare={props.showCompare}>
-          <S.LineSection>
+        <LineChartWithPieContainer showCompare={showCompare}>
+          <ChartContainer override={{ width: '100%' }}>
             <VerticalBarChart
               title="Traffic Stops By Percentage"
               data={stopsByPercentageData}
+              maintainAspectRatio={false}
               stacked
               disableLegend
               tooltipLabelCallback={formatTooltipValue}
@@ -728,25 +732,23 @@ function TrafficStops(props) {
                 chartTitle: stopsByPercentageModalTitle(),
               }}
             />
-          </S.LineSection>
+          </ChartContainer>
 
-          <S.PieSection alignItems="start">
-            <S.PieWrapper>
-              <PieChart
-                data={byPercentagePieData}
-                displayLegend={false}
-                maintainAspectRatio
-                modalConfig={{
-                  tableHeader: 'Traffic Stops By Percentage',
-                  tableSubheader: getPieChartModalSubHeading(
-                    'Shows the race/ethnic composition of drivers stopped',
-                    year
-                  ),
-                  agencyName: stopsChartState.data[AGENCY_DETAILS].name,
-                  chartTitle: pieChartTitle(),
-                }}
-              />
-            </S.PieWrapper>
+          <PieContainer>
+            <PieChart
+              data={byPercentagePieData}
+              displayLegend={false}
+              maintainAspectRatio
+              modalConfig={{
+                tableHeader: 'Traffic Stops By Percentage',
+                tableSubheader: getPieChartModalSubHeading(
+                  'Shows the race/ethnic composition of drivers stopped',
+                  year
+                ),
+                agencyName: stopsChartState.data[AGENCY_DETAILS].name,
+                chartTitle: pieChartTitle(),
+              }}
+            />
             <S.PieActionsWrapper>
               <DataSubsetPicker
                 label="Year"
@@ -755,8 +757,8 @@ function TrafficStops(props) {
                 options={[YEARS_DEFAULT].concat(stopsByPercentageData.labels.toReversed())}
               />
             </S.PieActionsWrapper>
-          </S.PieSection>
-        </S.ChartSubsection>
+          </PieContainer>
+        </LineChartWithPieContainer>
       </S.ChartSection>
       {/* Traffic Stops by Count */}
       <S.ChartSection id="stops_by_count">
@@ -808,7 +810,7 @@ function TrafficStops(props) {
           </S.LegendBeside>
         </S.ChartSubsection>
       </S.ChartSection>
-      <S.ChartSection marginTop={5} id="stops_by_purpose">
+      <S.ChartSection id="stops_by_purpose">
         <ChartHeader
           chartTitle="Traffic Stops By Stop Purpose"
           handleViewData={showStopPurposeModal}
@@ -828,8 +830,8 @@ function TrafficStops(props) {
           isOpen={stopPurposeModalData.isOpen}
           closeModal={() => setStopPurposeModalData((state) => ({ ...state, isOpen: false }))}
         />
-        <S.ChartSubsection showCompare={props.showCompare}>
-          <S.LineSection>
+        <LineChartWithPieContainer showCompare={showCompare}>
+          <ChartContainer override={{ width: '100%' }}>
             <LineChart
               data={stopPurposeGroupsData}
               title="Stop Purposes By Group"
@@ -845,24 +847,22 @@ function TrafficStops(props) {
                 chartTitle: getLineChartModalHeading('Traffic Stops By Group'),
               }}
             />
-          </S.LineSection>
-          <S.PieSection alignItems="start">
-            <S.PieWrapper>
-              <PieChart
-                data={stopPurposeGroupedPieData}
-                displayLegend={false}
-                maintainAspectRatio
-                modalConfig={{
-                  tableHeader: 'Traffic Stops By Stop Purpose',
-                  tableSubheader: getPieChartModalSubHeading(
-                    'Shows the stop purpose and race/ethnic composition of drivers stopped',
-                    groupedStopYear
-                  ),
-                  agencyName: stopsChartState.data[AGENCY_DETAILS].name,
-                  chartTitle: stopPurposeGroupPieChartTitle(),
-                }}
-              />
-            </S.PieWrapper>
+          </ChartContainer>
+          <PieContainer>
+            <PieChart
+              data={stopPurposeGroupedPieData}
+              displayLegend={false}
+              maintainAspectRatio
+              modalConfig={{
+                tableHeader: 'Traffic Stops By Stop Purpose',
+                tableSubheader: getPieChartModalSubHeading(
+                  'Shows the stop purpose and race/ethnic composition of drivers stopped',
+                  groupedStopYear
+                ),
+                agencyName: stopsChartState.data[AGENCY_DETAILS].name,
+                chartTitle: stopPurposeGroupPieChartTitle(),
+              }}
+            />
             <S.PieActionsWrapper>
               <DataSubsetPicker
                 label="Year"
@@ -871,8 +871,8 @@ function TrafficStops(props) {
                 options={stopPurposeGroupedPieYears()}
               />
             </S.PieActionsWrapper>
-          </S.PieSection>
-        </S.ChartSubsection>
+          </PieContainer>
+        </LineChartWithPieContainer>
       </S.ChartSection>
       <S.ChartSection marginTop={5} id="stops_by_purpose_and_count">
         <ChartHeader

--- a/frontend/src/Components/Charts/TrafficStops/TrafficStops.styled.js
+++ b/frontend/src/Components/Charts/TrafficStops/TrafficStops.styled.js
@@ -62,3 +62,18 @@ export const SwitchContainer = styled.div`
   margin-bottom: 10px;
   align-items: center;
 `;
+
+export const LineChartWithPieContainer = styled.div`
+  display: flex;
+  flex-direction: ${(props) => (props.showCompare ? 'column' : 'row')};
+  width: 100%;
+  flex-wrap: nowrap;
+
+  @media (${smallerThanDesktop}) {
+    flex-direction: column;
+  }
+`;
+
+export const PieContainer = styled.div`
+  width: 300px;
+`;

--- a/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
+++ b/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
@@ -27,9 +27,10 @@ import PieChart from '../../NewCharts/PieChart';
 import { pieChartConfig, pieChartLabels } from '../../../util/setChartColors';
 import VerticalBarChart from '../../NewCharts/VerticalBarChart';
 import axios from '../../../Services/Axios';
+import { ChartContainer } from '../ChartSections/ChartsCommon.styled';
 
 function UseOfForce(props) {
-  const { agencyId, showCompare } = props;
+  const { agencyId } = props;
   const officerId = useOfficerId();
 
   const [chartState] = useDataset(agencyId, USE_OF_FORCE);
@@ -153,8 +154,9 @@ function UseOfForce(props) {
             against.
           </P>
         </S.ChartDescription>
-        <S.ChartSubsection showCompare={showCompare}>
+        <ChartContainer>
           <VerticalBarChart
+            maintainAspectRatio={false}
             title="Use Of Force"
             data={useOfForceBarData}
             modalConfig={{
@@ -164,21 +166,20 @@ function UseOfForce(props) {
               chartTitle: chartModalTitle(false),
             }}
           />
-        </S.ChartSubsection>
-        <S.ChartSubsection>
-          <S.PieWrapper>
-            <PieChart
-              data={useOfForcePieData}
-              displayLegend={false}
-              maintainAspectRatio
-              modalConfig={{
-                tableHeader: 'Use of Force',
-                tableSubheader: getChartModalSubHeading(),
-                agencyName: chartState.data[AGENCY_DETAILS].name,
-                chartTitle: chartModalTitle(),
-              }}
-            />
-          </S.PieWrapper>
+        </ChartContainer>
+        <div>
+          <PieChart
+            data={useOfForcePieData}
+            displayLegend={false}
+            maintainAspectRatio
+            modalConfig={{
+              tableHeader: 'Use of Force',
+              tableSubheader: getChartModalSubHeading(),
+              agencyName: chartState.data[AGENCY_DETAILS].name,
+              chartTitle: chartModalTitle(),
+            }}
+          />
+
           <DataSubsetPicker
             label="Year"
             value={year}
@@ -186,7 +187,7 @@ function UseOfForce(props) {
             options={[YEARS_DEFAULT].concat(chartState.yearRange)}
             dropUp
           />
-        </S.ChartSubsection>
+        </div>
       </S.ChartSection>
     </UseOfForceStyled>
   );

--- a/frontend/src/Components/NewCharts/HorizontalBarChart.js
+++ b/frontend/src/Components/NewCharts/HorizontalBarChart.js
@@ -24,7 +24,7 @@ export const Tooltip = styled.div`
 export default function HorizontalBarChart({
   data,
   title,
-  maintainAspectRatio = true,
+  maintainAspectRatio = false,
   displayLegend = true,
   legendPosition = 'top',
   tooltipTitleCallback = null,

--- a/frontend/src/Components/NewCharts/VerticalBarChart.js
+++ b/frontend/src/Components/NewCharts/VerticalBarChart.js
@@ -109,10 +109,8 @@ export default function VerticalBarChart({
 
   return (
     <>
-      <div style={{ width: '100%' }}>
-        {!data.labels.length && <EmptyMessage />}
-        <Bar options={options} data={data} />
-      </div>
+      {!data.labels.length && <EmptyMessage />}
+      <Bar options={options} data={data} />
       <ChartModal
         isOpen={isChartOpen}
         closeModal={() => setIsChartOpen(false)}


### PR DESCRIPTION
Ticket:
- https://app.clickup.com/t/8686mb5nb

What's changed:
- Add a common `ChartContainer` so charts are responsive. This way its data is more accessible on mobile screens but keeping desktop experience as it was.

Preview:
![Screenshot 2024-04-01 at 11 52 21 AM](https://github.com/caktus/Traffic-Stops/assets/26633909/e2c5ed7c-587c-40e2-bb65-2069445917be)
