### PR TITLE
Fix Use of Force pie chart size

### DIFF
--- a/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
+++ b/frontend/src/Components/Charts/UseOfForce/UseOfForce.js
@@ -163,7 +163,7 @@ function UseOfForce(props) {
           <PieChart
             data={useOfForcePieData}
             displayLegend={false}
-            maintainAspectRatio
+            maintainAspectRatio={false}
             modalConfig={{
               tableHeader: 'Use of Force',
               tableSubheader: getChartModalSubHeading(),


### PR DESCRIPTION
Ticket:
- https://app.clickup.com/t/86886ymb2

What's changed:
- Update the pie chart component to pass a false value for the maintainAspectRatio flag, preventing the chart from taking up too much space.