### PR TITLE
Update contraband chart colors

### DIFF
--- a/frontend/src/Components/Charts/Contraband/Contraband.js
+++ b/frontend/src/Components/Charts/Contraband/Contraband.js
@@ -286,9 +286,9 @@ function Contraband(props) {
       .get(url)
       .then((res) => {
         const colors = {
-          'Safety Violation': '#5F0F40',
-          'Regulatory Equipment': '#E36414',
-          Other: '#0F4C5C',
+          'Safety Violation': '#E13DA2',
+          'Regulatory Equipment': '#EF8543',
+          Other: '#3EBFE0',
         };
         const stopPurposeDataSets = res.data.contraband_percentages.map((ds) => ({
           axis: 'x',


### PR DESCRIPTION
This PR handles updating the colors to brighter hues on the CONTRABAND "HIT RATE" GROUPED BY STOP PURPOSE chart. 


Before
![Screen Shot 2024-06-11 at 2 16 24 PM](https://github.com/caktus/Traffic-Stops/assets/32466511/7e36f817-b1c3-4602-8b2e-b2c2faf0f99e)


After
<img width="1180" alt="Screen Shot 2024-06-11 at 12 35 31 PM" src="https://github.com/caktus/Traffic-Stops/assets/32466511/f9fca658-1435-46de-bc53-35b83bfb8abc">