### PR TITLE
[CVE-2024-4323] Update New Relic Chart Version

### DIFF
--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -110,7 +110,7 @@ k8s_aws_load_balancer_type: nlb
 # k8s_papertrail_logspout_memory_limit: 128Mi
 
 # New Relic Account: forwardjustice-team@caktusgroup.com
-k8s_newrelic_chart_version: "5.0.68"
+k8s_newrelic_chart_version: "5.0.82"
 k8s_newrelic_logging_enabled: true
 k8s_newrelic_license_key: !vault |
   $ANSIBLE_VAULT;1.1;AES256


### PR DESCRIPTION
```
> helm -n newrelic list   
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
newrelic-bundle newrelic        5               2024-06-21 13:44:53.812967 -0400 EDT    deployed        nri-bundle-5.0.82                      
```

I ran the playbook (`inv playbook -n deploy-hosting-services.yml`) & made sure that the logs continued to go to New Relic. 

**Test**
1. Login to the New Relic (GP Cluster Account).
2. You can filter by `namespace_name: "ingress-nginx"`.
3. Go to a staging site of your choice, click around, and make sure that logs are still displaying as expected.

**Logs**
```
13:46:57.945
[pid: 15|app: 0|req: 6809/10274] 10.0.12.120 () {72 vars in 1554 bytes} [Fri Jun 21 13:46:57 2024] GET /api/agency/-1/ => generated 229 bytes in 47 msecs (HTTP/1.1 200) 9 headers in 271 bytes (1 switches on core 2)
 
13:46:58.110
[pid: 15|app: 0|req: 6810/10275] 10.0.12.120 () {72 vars in 1566 bytes} [Fri Jun 21 13:46:58 2024] GET /api/agency/-1/stops/ => generated 2823 bytes in 76 msecs (HTTP/1.1 200) 9 headers in 272 bytes (1 switches on core 3)
 
13:46:58.125
[pid: 14|app: 0|req: 1550/10276] 10.0.12.120 () {72 vars in 1580 bytes} [Fri Jun 21 13:46:58 2024] GET /api/agency/-1/use_of_force/ => generated 2289 bytes in 86 msecs (HTTP/1.1 200) 9 headers in 272 bytes (1 switches on core 3)
 
13:47:00.315
[pid: 15|app: 0|req: 6811/10277] 10.0.12.120 () {72 vars in 1593 bytes} [Fri Jun 21 13:47:00 2024] GET /api/agency/-1/use-of-force/ => generated 1350 bytes in 23 msecs (HTTP/1.1 200) 11 headers in 344 bytes (1 switches on core 0)
```

**Closes:**
 - https://app.clickup.com/t/8688tdwr3
