### PR TITLE
Fix Build post K8s/Python Upgrade

### DIFF
--- a/requirements/base/base.in
+++ b/requirements/base/base.in
@@ -1,6 +1,6 @@
 # base requirements.in
 django==3.2.25
-celery
+celery==5.4.0
 census==0.8.22
 us
 dealer
@@ -27,4 +27,5 @@ requests==2.32.3
 urllib3==2.2.1
 six
 whitenoise
-pandas<1.5
+pandas==2.2.2
+vine==5.1.0

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --output-file=requirements/base/base.txt requirements/base/base.in
 #
-amqp==2.6.0
+amqp==5.2.0
     # via kombu
 asgiref==3.5.2
     # via django
-billiard==3.6.3.0
+billiard==4.2.0
     # via celery
 boto==2.49.0
     # via -r requirements/base/base.in
@@ -19,7 +19,7 @@ botocore==1.34.100
     #   -r requirements/base/base.in
     #   boto3
     #   s3transfer
-celery==4.4.6
+celery==5.4.0
     # via -r requirements/base/base.in
 census==0.8.22
     # via -r requirements/base/base.in
@@ -30,7 +30,17 @@ charset-normalizer==3.0.1
 click==8.1.7
     # via
     #   -r requirements/base/base.in
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   django-click
+click-didyoumean==0.3.1
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.3.0
+    # via celery
 dealer==2.1.0
     # via -r requirements/base/base.in
 dj-database-url==0.5.0
@@ -75,8 +85,6 @@ djangorestframework==3.12.4
     #   drf-extensions
 drf-extensions==0.7.1
     # via -r requirements/base/base.in
-future==0.18.2
-    # via celery
 idna==2.10
     # via requests
 jellyfish==0.6.1
@@ -85,21 +93,23 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-kombu==4.6.11
+kombu==5.3.7
     # via celery
-numpy==1.22.3
+numpy==2.0.0
     # via pandas
-pandas==1.4.1
+pandas==2.2.2
     # via -r requirements/base/base.in
+prompt-toolkit==3.0.47
+    # via click-repl
 psycopg2==2.8.6
     # via -r requirements/base/base.in
-python-dateutil==2.8.1
+python-dateutil==2.9.0.post0
     # via
     #   botocore
+    #   celery
     #   pandas
 pytz==2022.1
     # via
-    #   celery
     #   django
     #   pandas
 redis==3.5.3
@@ -117,6 +127,10 @@ six==1.15.0
     #   python-dateutil
 sqlparse==0.3.1
     # via django
+tzdata==2024.1
+    # via
+    #   celery
+    #   pandas
 urllib3==2.2.1
     # via
     #   -r requirements/base/base.in
@@ -124,9 +138,13 @@ urllib3==2.2.1
     #   requests
 us==2.0.2
     # via -r requirements/base/base.in
-vine==1.3.0
+vine==5.1.0
     # via
+    #   -r requirements/base/base.in
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.13
+    # via prompt-toolkit
 whitenoise==5.1.0
     # via -r requirements/base/base.in

--- a/requirements/dev/dev.in
+++ b/requirements/dev/dev.in
@@ -13,6 +13,8 @@ Jinja2==3.1.4
 openshift==0.13.2
 kubernetes==12.0.0
 kubernetes-validate~=1.29.1
+referencing==0.35.1
+jsonschema==4.22
 
 troposphere
 

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -20,7 +20,7 @@ asgiref==3.5.2
     # via
     #   -c requirements/dev/../base/base.txt
     #   django
-attrs==19.3.0
+attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
@@ -91,7 +91,6 @@ idna==2.10
     # via
     #   -c requirements/dev/../base/base.txt
     #   requests
-    #   yarl
 imagesize==1.2.0
     # via sphinx
 importlib-resources==6.4.0
@@ -116,8 +115,12 @@ jmespath==1.0.1
     #   -c requirements/dev/../base/base.txt
     #   boto3
     #   botocore
-jsonschema==3.2.0
-    # via kubernetes-validate
+jsonschema==4.22.0
+    # via
+    #   -r requirements/dev/dev.in
+    #   kubernetes-validate
+jsonschema-specifications==2023.12.1
+    # via jsonschema
 kubernetes==12.0.0
     # via
     #   -r requirements/dev/dev.in
@@ -128,8 +131,6 @@ livereload==2.6.2
     # via sphinx-autobuild
 markupsafe==2.1.1
     # via jinja2
-multidict==6.0.5
-    # via yarl
 oauthlib==3.1.0
     # via requests-oauthlib
 openshift==0.13.2
@@ -152,8 +153,10 @@ pickleshare==0.7.5
     # via ipython
 port-for==0.3.1
     # via sphinx-autobuild
-prompt-toolkit==3.0.5
-    # via ipython
+prompt-toolkit==3.0.47
+    # via
+    #   -c requirements/dev/../base/base.txt
+    #   ipython
 ptyprocess==0.6.0
     # via pexpect
 pudb==2019.2
@@ -171,11 +174,7 @@ pygments==2.6.1
     #   ipython
     #   pudb
     #   sphinx
-pyrsistent==0.16.0
-    # via
-    #   jsonschema
-    #   referencing
-python-dateutil==2.8.1
+python-dateutil==2.9.0.post0
     # via
     #   -c requirements/dev/../base/base.txt
     #   -c requirements/dev/../test/test.txt
@@ -197,8 +196,12 @@ pyyaml==5.3.1
     #   kubernetes
     #   kubernetes-validate
     #   sphinx-autobuild
-referencing==0.8.11
-    # via kubernetes-validate
+referencing==0.35.1
+    # via
+    #   -r requirements/dev/dev.in
+    #   jsonschema
+    #   jsonschema-specifications
+    #   kubernetes-validate
 requests==2.32.3
     # via
     #   -c requirements/dev/../base/base.txt
@@ -209,6 +212,10 @@ requests-oauthlib==1.3.0
     # via kubernetes
 resolvelib==0.5.4
     # via ansible-core
+rpds-py==0.19.0
+    # via
+    #   jsonschema
+    #   referencing
 rsa==3.4.2
     # via
     #   awscli
@@ -226,11 +233,9 @@ six==1.15.0
     #   -c requirements/dev/../test/test.txt
     #   cfn-flip
     #   google-auth
-    #   jsonschema
     #   kubernetes
     #   livereload
     #   openshift
-    #   pyrsistent
     #   python-dateutil
     #   traitlets
     #   websocket-client
@@ -279,14 +284,14 @@ urwid==2.1.0
     # via pudb
 watchdog==0.10.3
     # via sphinx-autobuild
-wcwidth==0.1.9
-    # via prompt-toolkit
+wcwidth==0.2.13
+    # via
+    #   -c requirements/dev/../base/base.txt
+    #   prompt-toolkit
 websocket-client==0.57.0
     # via kubernetes
 wheel==0.37.1
     # via -r requirements/dev/dev.in
-yarl==1.9.4
-    # via referencing
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test/test.txt
+++ b/requirements/test/test.txt
@@ -69,7 +69,7 @@ pytest-cov==5.0.0
     # via -r requirements/test/test.in
 pytest-django==4.8.0
     # via -r requirements/test/test.in
-python-dateutil==2.8.1
+python-dateutil==2.9.0.post0
     # via
     #   -c requirements/test/../base/base.txt
     #   faker


### PR DESCRIPTION
This PR attempts to fix the build by updating necessary packages. It appears that #299 and #302 broke the build and deploy. 

The build is failing for two reasons:
1. Since the app now uses Python 3.10 some of the package versions were deprecated: `celery`, `numpy`, `pandas`, etc. Thus this error is showing:
```
ERROR: Could not find a version that satisfies the requirement celery==4.4.6 (from versions: 0.1.2, 0.1.4, 0.1.6, 0.1.7, 0.1.8, 0.1.10, 0.1.11, 0.1.12, 0.1.13, 0.1.14, 0.1.15, 0.2.0, 0.3.0, 0.3.7, 0.3.20, 0.4.0, 0.4.1, 0.6.0, 0.8.0, 0.8.1, 0.8.2, 0.8.3, 0.8.4, 1.0.0, 1.0.1, 1.0.2, 1.0.3, 1.0.4, 1.0.5, 1.0.6, 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.1.0, 2.1.1, 2.1.2, 2.1.3, 2.1.4, 2.2.0, 2.2.1, 2.2.2, 2.2.3, 2.2.4, 2.2.5, 2.2.6, 2.2.7, 2.2.8, 2.2.9, 2.2.10, 2.3.0, 2.3.1, 2.3.2, 2.3.3, 2.3.4, 2.3.5, 2.4.0, 2.4.1, 2.4.2, 2.4.3, 2.4.4, 2.4.5, 2.4.6, 2.4.7, 2.5.0, 2.5.1, 2.5.2, 2.5.3, 2.5.5, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.0.5, 3.0.6, 3.0.7, 3.0.8, 3.0.9, 3.0.10, 3.0.11, 3.0.12, 3.0.13, 3.0.14, 3.0.15, 3.0.16, 3.0.17, 3.0.18, 3.0.19, 3.0.20, 3.0.21, 3.0.22, 3.0.23, 3.0.24, 3.0.25, 3.1.0, 3.1.1, 3.1.2, 3.1.3, 3.1.4, 3.1.5, 3.1.6, 3.1.7, 3.1.8, 3.1.9, 3.1.10, 3.1.11, 3.1.12, 3.1.13, 3.1.14, 3.1.15, 3.1.16, 3.1.17, 3.1.18, 3.1.19, 3.1.20, 3.1.21, 3.1.22, 3.1.23, 3.1.24, 3.1.25, 3.1.26.post1, 3.1.26.post2, 4.0.0rc3, 4.0.0rc4, 4.0.0rc5, 4.0.0rc6, 4.0.0rc7, 4.0.0, 4.0.1, 4.0.2, 4.1.0, 4.1.1, 4.2.0rc1, 4.2.0rc2, 4.2.0rc3, 4.2.0rc4, 4.2.0, 4.2.1, 4.2.2, 4.3.0rc1, 4.3.0rc2, 4.3.0rc3, 4.3.0, 4.3.1, 4.4.0rc1, 4.4.0rc2, 4.4.0rc3, 4.4.0rc4, 4.4.0rc5, 4.4.0, 4.4.1, 4.4.2, 4.4.3, 4.4.4, 4.4.5, 4.4.6, 4.4.7, 5.0.0a1, 5.0.0a2, 5.0.0b1, 5.0.0rc1, 5.0.0rc2, 5.0.0rc3, 5.0.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.0.5, 5.1.0b1, 5.1.0b2, 5.1.0rc1, 5.1.0, 5.1.1, 5.1.2, 5.2.0b1, 5.2.0b2, 5.2.0b3, 5.2.0rc1, 5.2.0rc2, 5.2.0, 5.2.1, 5.2.2, 5.2.3, 5.2.4, 5.2.6, 5.2.7, 5.3.0a1, 5.3.0b1, 5.3.0b2, 5.3.0rc1, 5.3.0rc2, 5.3.0, 5.3.1, 5.3.4, 5.3.5, 5.3.6, 5.4.0rc1, 5.4.0rc2, 5.4.0)
```

2. Kubernetes validate has a weird issue with Ansible (may be a 🐛?) whereby it does not show as installed on deployments:
```
msg: Failed to import the required Python library (kubernetes-validate) on rana.lan's Python. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter
```
To prevent this, I pinned the following reqs on `dev.in`:
```
referencing==0.35.1
jsonschema==4.22
```

The deployment worked on my local machine.


**Test**
1. Pull the local changes, run `make setup` (The console mustn't show errors, such as [these](https://github.com/caktus/Traffic-Stops/pull/302#pullrequestreview-2164247268)).
2. Ensure the app runs locally. 


Closes:

- https://app.clickup.com/t/86890uc9q