### PR TITLE
Kubernetes Upgrade v1.29 to v1.30 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,8 +111,8 @@ RUN groupadd --gid $USER_GID $USERNAME \
 #   openssh-client -- for git over SSH
 #   sudo -- to run commands as superuser
 #   vim -- enhanced vi editor for commits
-ENV KUBE_CLIENT_VERSION="v1.29.4"
-ENV HELM_VERSION="3.14.4"
+ENV KUBE_CLIENT_VERSION="v1.30.7"
+ENV HELM_VERSION="3.16.3"
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     --mount=type=cache,mode=0755,target=/root/.cache/pip \
     set -ex \

--- a/deploy/deploy-cluster.yml
+++ b/deploy/deploy-cluster.yml
@@ -1,5 +1,8 @@
 - name: kubernetes cluster management
   hosts: cluster
   gather_facts: false
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
   roles:
     - role: caktus.k8s-web-cluster

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -90,9 +90,9 @@ k8s_iam_users: [copelco]
 # Pin ingress-nginx and cert-manager to current versions so future upgrades of this
 # role will not upgrade these charts without your intervention:
 # https://github.com/kubernetes/ingress-nginx/releases
-k8s_ingress_nginx_chart_version: "4.9.1"
+k8s_ingress_nginx_chart_version: "4.11.3"
 # https://github.com/jetstack/cert-manager/releases
-k8s_cert_manager_chart_version: "v1.14.3"
+k8s_cert_manager_chart_version: "v1.16.2"
 # AWS only:
 # Use the newer load balancer type (NLB). DO NOT edit k8s_aws_load_balancer_type after
 # creating your Service.
@@ -106,7 +106,7 @@ k8s_aws_load_balancer_type: nlb
 # k8s_papertrail_logspout_memory_limit: 128Mi
 
 # New Relic Account: forwardjustice-team@caktusgroup.com
-k8s_newrelic_chart_version: "5.0.68"
+k8s_newrelic_chart_version: "5.0.103"
 k8s_newrelic_logging_enabled: true
 k8s_newrelic_license_key: !vault |
   $ANSIBLE_VAULT;1.1;AES256

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -60,7 +60,7 @@ k8s_install_descheduler: yes
 # You must set the k8s_descheduler_chart_version to match the Kubernetes
 # node version (0.23.x -> K8s 1.23.x); see:
 # https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
-k8s_descheduler_chart_version: v0.29.0
+k8s_descheduler_chart_version: v0.30.2
 # See values.yaml for options:
 # https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
 k8s_descheduler_release_values:

--- a/deploy/group_vars/k8s.yml
+++ b/deploy/group_vars/k8s.yml
@@ -18,6 +18,8 @@ RepositoryURL: "606178775542.dkr.ecr.us-east-2.amazonaws.com"
 k8s_auth_host: "{{ ClusterEndpoint }}"
 k8s_auth_ssl_ca_cert: "k8s_auth_ssl_ca_cert.txt"
 k8s_namespace: "{{ app_name }}-{{ env_name }}"
+k8s_kubeconfig: "{{ playbook_dir + '/.kube/config' }}"
+k8s_context: "arn:aws:eks:us-east-2:606178775542:cluster/{{ k8s_cluster_name }}"
 
 k8s_ingress_certificate_issuer: letsencrypt-production
 

--- a/deploy/inventory-cdn
+++ b/deploy/inventory-cdn
@@ -1,4 +1,4 @@
-[k8s]
+[cdn]
 staging
 production
 

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -10,8 +10,8 @@
 
 - src: https://github.com/caktus/ansible-role-k8s-web-cluster
   name: caktus.k8s-web-cluster
-  version: v1.6.0
+  version: v1.7.0
 
 - src: https://github.com/caktus/ansible-role-k8s-hosting-services
   name: caktus.k8s-hosting-services
-  version: v0.12.0
+  version: v0.13.0

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -120,4 +120,4 @@ The application is behind a CloudFront distribution.
 
 To deploy the distribution, run::
 
-    ansible-playbook deploy-cf-stack.yml -t cdn -vvvv
+    ansible-playbook -i inventory-cdn deploy-cf-stack.yml -t cdn -vvvv

--- a/requirements/base/base.in
+++ b/requirements/base/base.in
@@ -5,8 +5,8 @@ census==0.8.22
 us
 dealer
 boto
-boto3==1.34.100
-botocore==1.34.100
+boto3==1.35.76
+botocore==1.35.76
 click==8.1.7
 # django-cache-machine is no longer used, remains for legacy migrations
 django-ckeditor==6.7.0

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -14,9 +14,9 @@ billiard==4.2.0
     # via celery
 boto==2.49.0
     # via -r requirements/base/base.in
-boto3==1.34.100
+boto3==1.35.76
     # via -r requirements/base/base.in
-botocore==1.34.100
+botocore==1.35.76
     # via
     #   -r requirements/base/base.in
     #   boto3

--- a/requirements/deploy/deploy.txt
+++ b/requirements/deploy/deploy.txt
@@ -8,11 +8,11 @@ certifi==2020.6.20
     # via
     #   -c requirements/deploy/../base/base.txt
     #   sentry-sdk
-newrelic==10.2.0
+newrelic==10.4.0
     # via -r requirements/deploy/deploy.in
 python3-memcached==1.51
     # via -r requirements/deploy/deploy.in
-sentry-sdk==2.17.0
+sentry-sdk==2.20.0
     # via -r requirements/deploy/deploy.in
 urllib3==2.2.1
     # via

--- a/requirements/dev/dev.in
+++ b/requirements/dev/dev.in
@@ -12,7 +12,7 @@ cffi
 Jinja2
 openshift
 kubernetes
-kubernetes-validate~=1.29.1
+kubernetes-validate==1.30
 referencing
 jsonschema
 
@@ -24,7 +24,7 @@ sphinx-autobuild
 rstcheck
 
 # AWS tools
-awscli==1.32.100
+awscli==1.36.17
 
 django-debug-toolbar
 

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -31,15 +31,15 @@ attrs==24.2.0
     # via
     #   jsonschema
     #   referencing
-awscli==1.32.100
+awscli==1.36.17
     # via -r requirements/dev/dev.in
 babel==2.16.0
     # via sphinx
-boto3==1.34.100
+boto3==1.35.76
     # via
     #   -c requirements/dev/../base/base.txt
     #   invoke-kubesae
-botocore==1.34.100
+botocore==1.35.76
     # via
     #   -c requirements/dev/../base/base.txt
     #   awscli
@@ -146,7 +146,7 @@ kubernetes==31.0.0
     # via
     #   -r requirements/dev/dev.in
     #   openshift
-kubernetes-validate==1.29.1
+kubernetes-validate==1.30.0
     # via -r requirements/dev/dev.in
 markdown-it-py==3.0.0
     # via rich

--- a/requirements/test/test.txt
+++ b/requirements/test/test.txt
@@ -81,7 +81,7 @@ six==1.15.0
     # via
     #   -c requirements/test/../base/base.txt
     #   python-dateutil
-tomli==2.0.2
+tomli==2.2.1
     # via
     #   black
     #   coverage


### PR DESCRIPTION
This PR serves as documentation/reference for the Kubernetes upgrade on the `trafficstops-stack-cluster` cluster. Currently the live site on this cluster are [nccopwatch](https://nccopwatch.org/) and [staging-nccopwatch.org](https://staging-nccopwatch.org/).

**Notes:**
 - There was zero downtime during the upgrade.

**Ingress Nginx**
```
 > helm -n ingress-nginx list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
ingress-nginx   ingress-nginx   9               2025-01-02 10:00:46.759808 -0500 EST    deployed        ingress-nginx-4.11.3    1.11.3
```

**Cert Manager**
```
> helm -n cert-manager list 
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
cert-manager    cert-manager    7               2025-01-02 10:01:33.427085 -0500 EST    deployed        cert-manager-v1.16.2    v1.16.2
```

**New Relic**
```
> helm -n newrelic list                 
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
newrelic-bundle newrelic        8               2025-01-27 15:27:48.997158 -0500 EST    deployed        nri-bundle-5.0.103               
```


**Descheduler Version**
```
> kubectl -n kube-system get cronjob -o yaml | grep descheduler
      app.kubernetes.io/name: descheduler
      helm.sh/chart: descheduler-0.30.2
    name: descheduler
            name: descheduler
              - /bin/descheduler
              image: registry.k8s.io/descheduler/descheduler:v0.30.2
```

![Screenshot 2025-01-23 at 2 28 00 PM](https://github.com/user-attachments/assets/a63e2412-1f12-4dbb-8e83-c452abe41ff0)


Closes:
 - https://app.clickup.com/t/868b4pucq
