### PR TITLE
Upgrade Postgres v12 to v16

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
       postgres:
         # From:
         # https://docs.github.com/en/actions/guides/creating-postgresql-service-containers
-        image: postgres:16
+        image: postgres:17
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: traffic_stops

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
       postgres:
         # From:
         # https://docs.github.com/en/actions/guides/creating-postgresql-service-containers
-        image: postgres:17
+        image: postgres:16
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: traffic_stops

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
       postgres:
         # From:
         # https://docs.github.com/en/actions/guides/creating-postgresql-service-containers
-        image: postgres
+        image: postgres:16
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: traffic_stops

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM python:3.10-slim-bullseye AS base
 ARG APP_USER=appuser
 RUN groupadd -r ${APP_USER} && useradd --no-log-init -r -g ${APP_USER} ${APP_USER}
 
-ENV POSTGRESQL_CLIENT_VERSION="17"
+ENV POSTGRESQL_CLIENT_VERSION="16"
 # Install packages needed to run your application (not build deps):
 #   postgresql-client -- for running database commands
 # We need to recreate the /usr/share/man/man{1..8} directories first because
@@ -117,7 +117,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
 #   vim -- enhanced vi editor for commits
 ENV KUBE_CLIENT_VERSION="v1.30.7"
 ENV HELM_VERSION="3.16.3"
-ENV POSTGRESQL_CLIENT_VERSION="17"
+ENV POSTGRESQL_CLIENT_VERSION="16"
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     --mount=type=cache,mode=0755,target=/root/.cache/pip \
     set -ex \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM python:3.10-slim-bullseye AS base
 ARG APP_USER=appuser
 RUN groupadd -r ${APP_USER} && useradd --no-log-init -r -g ${APP_USER} ${APP_USER}
 
-ENV POSTGRESQL_CLIENT_VERSION="16"
+ENV POSTGRESQL_CLIENT_VERSION="17"
 # Install packages needed to run your application (not build deps):
 #   postgresql-client -- for running database commands
 # We need to recreate the /usr/share/man/man{1..8} directories first because
@@ -117,7 +117,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
 #   vim -- enhanced vi editor for commits
 ENV KUBE_CLIENT_VERSION="v1.30.7"
 ENV HELM_VERSION="3.16.3"
-ENV POSTGRESQL_CLIENT_VERSION="16"
+ENV POSTGRESQL_CLIENT_VERSION="17"
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     --mount=type=cache,mode=0755,target=/root/.cache/pip \
     set -ex \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM python:3.10-slim-bullseye AS base
 ARG APP_USER=appuser
 RUN groupadd -r ${APP_USER} && useradd --no-log-init -r -g ${APP_USER} ${APP_USER}
 
+ENV POSTGRESQL_CLIENT_VERSION="16"
 # Install packages needed to run your application (not build deps):
 #   postgresql-client -- for running database commands
 # We need to recreate the /usr/share/man/man{1..8} directories first because
@@ -21,7 +22,7 @@ RUN set -ex \
     && RUN_DEPS=" \
     libpcre3 \
     mime-support \
-    postgresql-client \
+    postgresql-client-${POSTGRESQL_CLIENT_VERSION} \
     vim \
     " \
     && seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{} \
@@ -113,6 +114,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
 #   vim -- enhanced vi editor for commits
 ENV KUBE_CLIENT_VERSION="v1.30.7"
 ENV HELM_VERSION="3.16.3"
+ENV POSTGRESQL_CLIENT_VERSION="16"
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     --mount=type=cache,mode=0755,target=/root/.cache/pip \
     set -ex \
@@ -127,7 +129,8 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
     libpq-dev \
     nodejs \
     openssh-client \
-    postgresql-client-12 \
+    postgresql-client-${POSTGRESQL_CLIENT_VERSION} \
+    psql \
     sudo \
     vim \
     " \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,13 @@ ENV POSTGRESQL_CLIENT_VERSION="16"
 #   postgresql-client -- for running database commands
 # We need to recreate the /usr/share/man/man{1..8} directories first because
 # they were clobbered by a parent image.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN set -ex \
+    && RUN_DEPS=" \
     libpcre3 \
     mime-support \
     postgresql-client-${POSTGRESQL_CLIENT_VERSION} \
     vim \
+    " \
     && seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{} \
     && apt-get update && apt-get install -y --no-install-recommends $RUN_DEPS \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     mime-support \
     postgresql-client-${POSTGRESQL_CLIENT_VERSION} \
     vim \
-    " \
     && seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{} \
     && apt-get update && apt-get install -y --no-install-recommends $RUN_DEPS \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ ENV POSTGRESQL_CLIENT_VERSION="16"
 #   postgresql-client -- for running database commands
 # We need to recreate the /usr/share/man/man{1..8} directories first because
 # they were clobbered by a parent image.
-RUN set -ex \
-    && RUN_DEPS=" \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     libpcre3 \
     mime-support \
     postgresql-client-${POSTGRESQL_CLIENT_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN set -ex \
     vim \
     " \
     && seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{} \
+    && apt-get update && apt-get -y install wget gnupg2 lsb-release \
+    && sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update && apt-get install -y --no-install-recommends $RUN_DEPS \
     && rm -rf /var/lib/apt/lists/*
 

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -24,12 +24,12 @@ admin_database_password: !vault |
 # ----------------------------------------------------------------------------
 
 # Parameters
-cloudformation_stack_database_engine_version: "16.3"
-cloudformation_stack_database_parameter_group_family: postgres15
+cloudformation_stack_database_engine_version: "16.6"
+cloudformation_stack_database_parameter_group_family: postgres16
 
-# Must match PostgreSQL version, e.g. v16 for DB restore
-# TODO: Find & update to correct tag in v16
-k8s_hosting_services_image_tag: 0.6.0-postgres16
+# Find tag:
+# https://github.com/caktus/k8s-caktus-backup/pkgs/container/k8s-caktus-backup
+k8s_hosting_services_image_tag: 0.7.0-postgres17
 
 cloudformation_stack_state: present
 cloudformation_stack_profile: '{{ aws_profile }}'
@@ -45,7 +45,7 @@ cloudformation_stack_template_parameters:
   MaxScale: 4
   UseAES256Encryption: "true"
   CustomerManagedCmkArn: ""
-  ContainerInstanceType: db.t4g.xlarge
+  ContainerInstanceType: t3a.large
   ContainerVolumeSize: 40
   DatabaseAllocatedStorage: 100
   DatabaseClass: db.t4g.xlarge

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -24,8 +24,8 @@ admin_database_password: !vault |
 # ----------------------------------------------------------------------------
 
 # Parameters
-cloudformation_stack_database_engine_version: "17.2"
-cloudformation_stack_database_parameter_group_family: postgres17
+cloudformation_stack_database_engine_version: "16.6"
+cloudformation_stack_database_parameter_group_family: postgres16
 
 # Find tag:
 # https://github.com/caktus/k8s-caktus-backup/pkgs/container/k8s-caktus-backup

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -23,6 +23,14 @@ admin_database_password: !vault |
 #                        provisioning with aws-web-stacks.
 # ----------------------------------------------------------------------------
 
+# Parameters
+cloudformation_stack_database_engine_version: "16.3"
+cloudformation_stack_database_parameter_group_family: postgres15
+
+# Must match PostgreSQL version, e.g. v16 for DB restore
+# TODO: Find & update to correct tag in v16
+k8s_hosting_services_image_tag: 0.6.0-postgres16
+
 cloudformation_stack_state: present
 cloudformation_stack_profile: '{{ aws_profile }}'
 cloudformation_stack_region: '{{ aws_region }}'
@@ -41,8 +49,8 @@ cloudformation_stack_template_parameters:
   ContainerVolumeSize: 40
   DatabaseAllocatedStorage: 100
   DatabaseClass: db.t4g.xlarge
-  DatabaseEngineVersion: "12"
-  DatabaseParameterGroupFamily: postgres12
+  DatabaseEngineVersion: "{{ cloudformation_stack_database_engine_version }}"
+  DatabaseParameterGroupFamily: "{{ cloudformation_stack_database_parameter_group_family }}"
   DatabaseMultiAZ: "false"
   DatabaseUser: "{{ app_name }}_admin"
   DatabasePassword: "{{ admin_database_password }}"
@@ -54,21 +62,6 @@ cloudformation_stack_template_parameters:
   AssetsUseCloudFront: "true"
 cloudformation_stack_tags:
   Environment: "{{ app_name }}"
-
-# Install Descheduler to attempt to spread out pods again after node failures
-k8s_install_descheduler: yes
-# You must set the k8s_descheduler_chart_version to match the Kubernetes
-# node version (0.23.x -> K8s 1.23.x); see:
-# https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
-k8s_descheduler_chart_version: v0.30.2
-# See values.yaml for options:
-# https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
-k8s_descheduler_release_values:
-  deschedulerPolicy:
-    strategies:
-      # During upgrades or reboots, don't pre-emptively drain a node.
-      RemovePodsViolatingNodeTaints:
-        enabled: false
 
 # ----------------------------------------------------------------------------
 # caktus.k8s-web-cluster: An Ansible role to help configure Kubernetes
@@ -102,9 +95,6 @@ k8s_aws_load_balancer_type: nlb
 # caktus.k8s-hosting-services: Logging and monitoring configuration
 # ----------------------------------------------------------------------------
 
-# k8s_papertrail_logspout_destination: "syslog+tls://logs2.papertrailapp.com:20851"
-# k8s_papertrail_logspout_memory_limit: 128Mi
-
 # New Relic Account: forwardjustice-team@caktusgroup.com
 k8s_newrelic_chart_version: "5.0.103"
 k8s_newrelic_logging_enabled: true
@@ -116,3 +106,18 @@ k8s_newrelic_license_key: !vault |
   3163313364666132340a636330353366613061306361303737303332383431336263323135393232
   65303530343134383464616561383139643263326661636133316534303934346438643366666663
   3136353834393937356364356235393236643835663965643532
+
+# Install Descheduler to attempt to spread out pods again after node failures
+k8s_install_descheduler: yes
+# You must set the k8s_descheduler_chart_version to match the Kubernetes
+# node version (0.23.x -> K8s 1.23.x); see:
+# https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
+k8s_descheduler_chart_version: v0.30.2
+# See values.yaml for options:
+# https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
+k8s_descheduler_release_values:
+  deschedulerPolicy:
+    strategies:
+      # During upgrades or reboots, don't pre-emptively drain a node.
+      RemovePodsViolatingNodeTaints:
+        enabled: false

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -24,12 +24,12 @@ admin_database_password: !vault |
 # ----------------------------------------------------------------------------
 
 # Parameters
-cloudformation_stack_database_engine_version: "16.6"
-cloudformation_stack_database_parameter_group_family: postgres16
+cloudformation_stack_database_engine_version: "17.2"
+cloudformation_stack_database_parameter_group_family: postgres17
 
 # Find tag:
 # https://github.com/caktus/k8s-caktus-backup/pkgs/container/k8s-caktus-backup
-k8s_hosting_services_image_tag: 0.7.0-postgres17
+k8s_hosting_services_image_tag: 0.7.0-postgres16
 
 cloudformation_stack_state: present
 cloudformation_stack_profile: '{{ aws_profile }}'

--- a/deploy/stack/eks-no-nat.yml
+++ b/deploy/stack/eks-no-nat.yml
@@ -695,6 +695,7 @@ Parameters:
       - db.t3.large
       - db.t3.xlarge
       - db.t3.2xlarge
+      - db.t4g.xlarge
       - db.m1.small
       - db.m1.medium
       - db.m1.large
@@ -802,6 +803,7 @@ Parameters:
       - postgres14
       - postgres15
       - postgres16
+      - postgres17
       - sqlserver-ee-11.0
       - sqlserver-ee-12.0
       - sqlserver-ee-13.0

--- a/deploy/stack/eks-no-nat.yml
+++ b/deploy/stack/eks-no-nat.yml
@@ -798,6 +798,10 @@ Parameters:
       - postgres10
       - postgres11
       - postgres12
+      - postgres13
+      - postgres14
+      - postgres15
+      - postgres16
       - sqlserver-ee-11.0
       - sqlserver-ee-12.0
       - sqlserver-ee-13.0
@@ -1398,9 +1402,10 @@ Resources:
     Type: AWS::EC2::SecurityGroup
   DatabaseInstance:
     Condition: DatabaseCondition
-    DeletionPolicy: Snapshot
+    DeletionPolicy: Retain
     Properties:
       AllocatedStorage: !Ref 'DatabaseAllocatedStorage'
+      AllowMajorVersionUpgrade: 'true'
       BackupRetentionPeriod: !Ref 'DatabaseBackupRetentionDays'
       DBInstanceClass: !Ref 'DatabaseClass'
       DBName: !Ref 'DatabaseName'

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,9 +1,7 @@
-version: '3.4'
-
 services:
   django:
     image: trafficstops_app:latest
-    command: ["uwsgi", "--show-config"]
+    command: [ "uwsgi", "--show-config" ]
     environment:
       DJANGO_MANAGEPY_MIGRATE: "on"
     env_file:
@@ -17,7 +15,7 @@ services:
       - "8000:8000"
   worker:
     image: trafficstops_app:latest
-    command: ["celery", "--app=traffic_stops", "worker", "-l", "info"]
+    command: [ "celery", "--app=traffic_stops", "worker", "-l", "info" ]
     env_file:
       - .docker.env
     links:
@@ -28,7 +26,7 @@ services:
       - mailhog
   beat:
     image: trafficstops_app:latest
-    command: ["celery", "--app=traffic_stops", "beat", "--pidfile=/tmp/celerybeat.pid", "--schedule=/tmp/celerybeat-schedule", "-l", "info"]
+    command: [ "celery", "--app=traffic_stops", "beat", "--pidfile=/tmp/celerybeat.pid", "--schedule=/tmp/celerybeat-schedule", "-l", "info" ]
     env_file:
       - .docker.env
     links:
@@ -44,7 +42,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_DB: traffic_stops
       DATABASE_URL: postgres://postgres@127.0.0.1:5432/traffic_stops
-    image: postgres:12-alpine
+    image: postgres:16-alpine
     ports:
       - "9051:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_DB: traffic_stops
       DATABASE_URL: postgres://postgres@127.0.0.1:5432/traffic_stops
-    image: postgres:17-alpine
+    image: postgres:16-alpine
     ports:
       - "9051:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_DB: traffic_stops
       DATABASE_URL: postgres://postgres@127.0.0.1:5432/traffic_stops
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     ports:
       - "9051:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_DB: traffic_stops
       DATABASE_URL: postgres://postgres@127.0.0.1:5432/traffic_stops
-    image: postgres:12-alpine
+    image: postgres:16-alpine
     ports:
       - "9051:5432"
     volumes:
@@ -39,7 +39,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: dev
-    command: ["sleep", "infinity"]
+    command: [ "sleep", "infinity" ]
     links:
       - db:db
       - redis:redis

--- a/docs/dev-setup.rst
+++ b/docs/dev-setup.rst
@@ -8,7 +8,7 @@ your local development system:
 - Python 3.10
 - NodeJS >= 12.6.0
 - `pip >= 8 or so <http://www.pip-installer.org/>`_
-- Postgres >= 17
+- Postgres >= 16
 
 Getting Started (Docker 🐳)
 ---------------------------

--- a/docs/dev-setup.rst
+++ b/docs/dev-setup.rst
@@ -8,7 +8,7 @@ your local development system:
 - Python 3.10
 - NodeJS >= 12.6.0
 - `pip >= 8 or so <http://www.pip-installer.org/>`_
-- Postgres >= 12
+- Postgres >= 16
 
 Getting Started (Docker 🐳)
 ---------------------------

--- a/docs/dev-setup.rst
+++ b/docs/dev-setup.rst
@@ -8,7 +8,7 @@ your local development system:
 - Python 3.10
 - NodeJS >= 12.6.0
 - `pip >= 8 or so <http://www.pip-installer.org/>`_
-- Postgres >= 16
+- Postgres >= 17
 
 Getting Started (Docker 🐳)
 ---------------------------


### PR DESCRIPTION
## Summary

This PR updates the client version of Postgres from v12 to v15. Postgres 12 reached EOL on **Nov 14, 2024**. 

- [x] Use `postgresql-client-15` client in Dockerfile
- [x] Use `postgres:15` in `.github/workflows/test.yml` and tests pass
- [x] postgres-client-15 installs automatically in container (e.g. `psql` command exists)
- [x] Use `postgres:15` in `docker-compose.yaml`
- [x] Update caktus.k8s-hosting-services PostgreSQL backup image to use `x.x.x-postgres16`


Closes:
 - https://app.clickup.com/t/868b4qh6g
