### PR TITLE
Update Ingress Nginx Chart

### DIFF
--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -84,9 +84,9 @@ k8s_iam_users: [copelco]
 # Pin ingress-nginx and cert-manager to current versions so future upgrades of this
 # role will not upgrade these charts without your intervention:
 # https://github.com/kubernetes/ingress-nginx/releases
-k8s_ingress_nginx_chart_version: "4.11.3"
+k8s_ingress_nginx_chart_version: "4.11.5"
 # https://github.com/jetstack/cert-manager/releases
-k8s_cert_manager_chart_version: "v1.16.2"
+k8s_cert_manager_chart_version: "v1.17.1"
 # AWS only:
 # Use the newer load balancer type (NLB). DO NOT edit k8s_aws_load_balancer_type after
 # creating your Service.
@@ -97,7 +97,7 @@ k8s_aws_load_balancer_type: nlb
 # ----------------------------------------------------------------------------
 
 # New Relic Account: forwardjustice-team@caktusgroup.com
-k8s_newrelic_chart_version: "5.0.103"
+k8s_newrelic_chart_version: "5.0.117"
 k8s_newrelic_logging_enabled: true
 k8s_newrelic_license_key: !vault |
   $ANSIBLE_VAULT;1.1;AES256


### PR DESCRIPTION
Some people at Wiz wrote a great post about this: https://www.wiz.io/blog/ingress-nginx-kubernetes-vulnerabilities

_Ingress Nginx version update (and other packages)_

**Ingress Nginx**
```sh
> helm -n ingress-nginx list 
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
ingress-nginx   ingress-nginx   10              2025-03-26 10:57:17.291342 -0400 EDT    deployed        ingress-nginx-4.11.5    1.11.5  
```

**Cert Manager**
```sh
> helm -n cert-manager list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
cert-manager    cert-manager    9               2025-03-26 10:58:38.865938 -0400 EDT    deployed        cert-manager-v1.17.1    v1.17.1  
```

New Relic
```sh
> helm -n newrelic list    
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
newrelic-bundle newrelic        9               2025-03-26 10:59:56.140238 -0400 EDT    deployed        nri-bundle-5.0.117                
```

_Ensure the admission webhook endpoint is not exposed externally_ 

```
> kubectl get svc -n ...-production
NAME           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
app            ClusterIP   [IP Num here]    <none>        8000/TCP   4y218d
beat-service   ClusterIP   None            <none>        <none>     4y218d
redis          ClusterIP   [IP Num here]    <none>        6379/TCP   4y218d

 > kubectl get svc -n ...-staging   
NAME           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
app            ClusterIP   [IP Num here]    <none>        8000/TCP   4y218d
beat-service   ClusterIP   None             <none>        <none>     4y218d
redis          ClusterIP   [IP Num here]     <none>        6379/TCP   4y218d

```

Traffic Stops svc is of type ClusterIP. ClusterIP services are only accessible from within the cluster, you cannot directly curl it from outside. More on that [here](https://www.linkedin.com/pulse/clusterip-service-kubernetes-christopher-adamson-jvy3c#:~:text=When%20you%20create%20a%20ClusterIP,cannot%20be%20reached%20from%20outside.).


Closes:
 - https://app.clickup.com/t/868d7jm29