### PR TITLE
Update Ubuntu on Deploy Job

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       ENV: staging
       GITHUB_ENV: https://staging.nccopwatch.org/


### PR DESCRIPTION
This PR updates the Ubuntu version from deprecated `v20.04` to `latest`, ensuring the following error won't happen again. 

```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15.
```