### PR TITLE
task: reorder likelihood of stop table modal columns.

### DIFF
--- a/frontend/src/Components/Charts/chartUtils.js
+++ b/frontend/src/Components/Charts/chartUtils.js
@@ -256,16 +256,16 @@ export const LIKELIHOOD_OF_STOP_TABLE_COLUMNS = [
     accessor: 'population',
   },
   {
-    Header: 'Basline Rate',
-    accessor: 'baseline_rate',
-  },
-  {
     Header: 'Stops',
     accessor: 'stops',
   },
   {
     Header: 'Stop Rate',
     accessor: 'stop_rate',
+  },
+  {
+    Header: 'Basline Rate',
+    accessor: 'baseline_rate',
   },
   {
     Header: 'Stop Rate Ratio',


### PR DESCRIPTION
This PR handles reordering the table columns so "baseline rate" appears after "stop rate".

Before: 
<img width="990" alt="Screen Shot 2025-06-17 at 1 19 51 PM" src="https://github.com/user-attachments/assets/7c3964cc-baca-4e6b-838f-afe79a2bd3d0" />

After:
<img width="992" alt="Screen Shot 2025-06-17 at 1 18 27 PM" src="https://github.com/user-attachments/assets/cb242c73-3934-48ce-a890-c1fb0ac25f5b" />
