### PR TITLE
Kubernetes Upgrade v1.30 to v1.32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,8 +118,8 @@ RUN groupadd --gid $USER_GID $USERNAME \
 #   openssh-client -- for git over SSH
 #   sudo -- to run commands as superuser
 #   vim -- enhanced vi editor for commits
-ENV KUBE_CLIENT_VERSION="v1.30.7"
-ENV HELM_VERSION="3.16.3"
+ENV KUBE_CLIENT_VERSION="v1.32.6"
+ENV HELM_VERSION="3.18.3"
 ENV POSTGRESQL_CLIENT_VERSION="16"
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     --mount=type=cache,mode=0755,target=/root/.cache/pip \

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -84,7 +84,7 @@ k8s_iam_users: [copelco]
 # Pin ingress-nginx and cert-manager to current versions so future upgrades of this
 # role will not upgrade these charts without your intervention:
 # https://github.com/kubernetes/ingress-nginx/releases
-k8s_ingress_nginx_chart_version: "4.11.5"
+k8s_ingress_nginx_chart_version: "4.12.3"
 # https://github.com/jetstack/cert-manager/releases
 k8s_cert_manager_chart_version: "v1.17.2"
 # AWS only:
@@ -113,7 +113,7 @@ k8s_install_descheduler: yes
 # You must set the k8s_descheduler_chart_version to match the Kubernetes
 # node version (0.23.x -> K8s 1.23.x); see:
 # https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
-k8s_descheduler_chart_version: v0.31.0
+k8s_descheduler_chart_version: v0.32.2
 # See values.yaml for options:
 # https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
 k8s_descheduler_release_values:

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -86,7 +86,7 @@ k8s_iam_users: [copelco]
 # https://github.com/kubernetes/ingress-nginx/releases
 k8s_ingress_nginx_chart_version: "4.11.5"
 # https://github.com/jetstack/cert-manager/releases
-k8s_cert_manager_chart_version: "v1.17.1"
+k8s_cert_manager_chart_version: "v1.17.2"
 # AWS only:
 # Use the newer load balancer type (NLB). DO NOT edit k8s_aws_load_balancer_type after
 # creating your Service.
@@ -97,7 +97,7 @@ k8s_aws_load_balancer_type: nlb
 # ----------------------------------------------------------------------------
 
 # New Relic Account: forwardjustice-team@caktusgroup.com
-k8s_newrelic_chart_version: "5.0.117"
+k8s_newrelic_chart_version: "6.0.1"
 k8s_newrelic_logging_enabled: true
 k8s_newrelic_license_key: !vault |
   $ANSIBLE_VAULT;1.1;AES256
@@ -113,7 +113,7 @@ k8s_install_descheduler: yes
 # You must set the k8s_descheduler_chart_version to match the Kubernetes
 # node version (0.23.x -> K8s 1.23.x); see:
 # https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
-k8s_descheduler_chart_version: v0.30.2
+k8s_descheduler_chart_version: v0.31.0
 # See values.yaml for options:
 # https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
 k8s_descheduler_release_values:

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -2,7 +2,7 @@
 
 - src: https://github.com/caktus/ansible-role-django-k8s
   name: caktus.django-k8s
-  version: v1.9.0
+  version: v1.10.1
 
 - src: https://github.com/caktus/ansible-role-aws-web-stacks
   name: caktus.aws-web-stacks
@@ -10,7 +10,7 @@
 
 - src: https://github.com/caktus/ansible-role-k8s-web-cluster
   name: caktus.k8s-web-cluster
-  version: v1.7.0
+  version: v1.8.0
 
 - src: https://github.com/caktus/ansible-role-k8s-hosting-services
   name: caktus.k8s-hosting-services

--- a/requirements/base/base.in
+++ b/requirements/base/base.in
@@ -5,8 +5,8 @@ census==0.8.24
 us
 dealer
 boto
-boto3==1.35.76
-botocore==1.35.76
+boto3==1.39.2
+botocore==1.39.2
 click==8.1.7
 # django-cache-machine is no longer used, remains for legacy migrations
 django-ckeditor==6.7.0

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -14,9 +14,9 @@ billiard==4.2.0
     # via celery
 boto==2.49.0
     # via -r requirements/base/base.in
-boto3==1.35.76
+boto3==1.39.2
     # via -r requirements/base/base.in
-botocore==1.35.76
+botocore==1.39.2
     # via
     #   -r requirements/base/base.in
     #   boto3
@@ -140,7 +140,7 @@ requests==2.32.3
     # via
     #   -r requirements/base/base.in
     #   census
-s3transfer==0.10.1
+s3transfer==0.13.0
     # via boto3
 six==1.15.0
     # via

--- a/requirements/dev/dev.in
+++ b/requirements/dev/dev.in
@@ -12,7 +12,7 @@ cffi
 Jinja2
 openshift
 kubernetes
-kubernetes-validate==1.30
+kubernetes-validate~=1.32
 referencing
 jsonschema
 
@@ -24,7 +24,7 @@ sphinx-autobuild
 rstcheck
 
 # AWS tools
-awscli==1.36.17
+awscli==1.41.2
 
 django-debug-toolbar
 

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -31,15 +31,15 @@ attrs==24.2.0
     # via
     #   jsonschema
     #   referencing
-awscli==1.36.17
+awscli==1.41.2
     # via -r requirements/dev/dev.in
 babel==2.16.0
     # via sphinx
-boto3==1.35.76
+boto3==1.39.2
     # via
     #   -c requirements/dev/../base/base.txt
     #   invoke-kubesae
-botocore==1.35.76
+botocore==1.39.2
     # via
     #   -c requirements/dev/../base/base.txt
     #   awscli
@@ -86,7 +86,7 @@ django==3.2.25
     #   django-debug-toolbar
 django-debug-toolbar==4.3.0
     # via -r requirements/dev/dev.in
-docutils==0.16
+docutils==0.19
     # via
     #   awscli
     #   rstcheck-core
@@ -146,7 +146,7 @@ kubernetes==31.0.0
     # via
     #   -r requirements/dev/dev.in
     #   openshift
-kubernetes-validate==1.30.0
+kubernetes-validate==1.33.1
     # via -r requirements/dev/dev.in
 markdown-it-py==3.0.0
     # via rich
@@ -251,7 +251,7 @@ rstcheck==6.2.4
     # via -r requirements/dev/dev.in
 rstcheck-core==1.2.1
     # via rstcheck
-s3transfer==0.10.1
+s3transfer==0.13.0
     # via
     #   -c requirements/dev/../base/base.txt
     #   awscli


### PR DESCRIPTION
This PR updates requirements to work with K8s version `1.32.x`.

**Ingress Nginx**
```
> helm -n ingress-nginx list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
ingress-nginx   ingress-nginx   11              2025-07-11 10:19:15.038463 -0400 EDT    deployed        ingress-nginx-4.12.3    1.12.3    
```

**Cert Manager**
```
> helm -n cert-manager list                      
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
cert-manager    cert-manager    10              2025-07-11 09:51:23.552681 -0400 EDT    deployed        cert-manager-v1.17.2    v1.17.2   
```

**New Relic**
```
> helm -n newrelic list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
newrelic-bundle newrelic        10              2025-07-11 09:54:13.492946 -0400 EDT    deployed        nri-bundle-6.0.1 
```

**Descheduler**
```
> helm -n kube-system list                
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
descheduler     kube-system     13              2025-07-11 11:33:57.687054 -0400 EDT    deployed        descheduler-0.32.2      0.32.2   
```

**Helm and Kube Client**
```
 ❯ helm version --short
v3.14.4+g81c902a

❯ kubectl version --client
Client Version: v1.29.4
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
```
  
**Cluster and pods version** 

<img width="1798" height="1000" alt="Screenshot 2025-07-11 at 11 52 50 AM" src="https://github.com/user-attachments/assets/c2855491-c9c3-4328-9afd-36d45f6a79eb" />


Closes:
     - https://app.clickup.com/t/868e6zrab