### PR TITLE
Prevent API error if no ACS data exists for query

### DIFF
--- a/nc/tests/api/test_arrests.py
+++ b/nc/tests/api/test_arrests.py
@@ -10,6 +10,7 @@ from nc.tests.factories import ContrabandFactory, PersonFactory, SearchFactory
 from nc.tests.urls import reverse_querystring
 from nc.views.arrests import sort_by_stop_purpose
 
+
 class ArrestUtilityTests(TestCase):
     def test_sort_by_stop_purpose(self):
         """Sort DataFrame by stop_purpose column in order of the IntegerChoices"""

--- a/nc/views/main.py
+++ b/nc/views/main.py
@@ -1361,7 +1361,6 @@ class AgencySearchRateView(APIView):
             ],
         }
 
-
     def get(self, request, agency_id):
         stop_qs = StopSummary.objects.all().annotate(year=ExtractYear("date"))
         search_qs = StopSummary.objects.filter(search_type__isnull=False).annotate(

--- a/tasks.py
+++ b/tasks.py
@@ -35,7 +35,7 @@ def pod_stats(c):
 @invoke.task
 def ansible_playbook(c, name, extra="", verbosity=1):
     with c.cd("deploy/"):
-        c.run(f"ansible-playbook {name} {extra} -{'v'*verbosity}")
+        c.run(f"ansible-playbook {name} {extra} -{'v' * verbosity}")
 
 
 @invoke.task


### PR DESCRIPTION
Return an empty ACS dataframe with correct columns if no ACS data is found.

### Steps to test
* Visit http://localhost:3000/agencies/80/search-rate
* Choose 2025 in the year dropdown
* No exception in terminal