### PR TITLE
Make the agency header sticky when scrolling.

### DIFF
--- a/frontend/src/Components/AgencyData/AgencyHeader.js
+++ b/frontend/src/Components/AgencyData/AgencyHeader.js
@@ -55,7 +55,10 @@ function AgencyHeader({
       {agencyHeaderOpen && (
         <S.AgencyHeader>
           <S.SubHeaderNavRow>{!showCompareDepartments && <BackButton />}</S.SubHeaderNavRow>
-          <S.SubHeaderContentRow flexDirection={showCompareDepartments ? 'column' : 'row'}>
+          <S.SubHeaderContentRow
+            flexDirection={showCompareDepartments ? 'column' : 'row'}
+            justifyContent="space-between"
+          >
             <S.EntityDetails>
               {officerId ? (
                 <>

--- a/frontend/src/Components/AgencyData/AgencyHeader.js
+++ b/frontend/src/Components/AgencyData/AgencyHeader.js
@@ -3,6 +3,7 @@ import { useTheme } from 'styled-components';
 import { AnimatePresence } from 'framer-motion';
 import * as S from './AgencyHeader.styled';
 import { P, SIZES, WEIGHTS, COLORS } from '../../styles/StyledComponents/Typography';
+import { phoneOnly } from '../../styles/breakpoints';
 
 // Routing
 import { useHistory, useParams } from 'react-router-dom';
@@ -96,49 +97,57 @@ function AgencyHeader({
               showCompareDepartments={showCompareDepartments}
             />
           </S.SubHeaderContentRow>
-          <DataSubsetPicker
-            label="Year"
-            value={year}
-            onChange={handleYearSelect}
-            options={yearRange}
-            dropDown
-          />
-          {!showCloseButton && (
-            <S.AgencyHeaderButton>
-              <Button
-                variant="positive"
-                border={`2px solid ${theme.colors.primary}`}
-                {...ChartHeaderStyles.ButtonInlines}
-                onClick={() => toggleShowCompare()}
-              >
-                <ChartHeaderStyles.Icon
-                  icon={showCompareDepartments ? ICONS.checkboxFilled : ICONS.checkboxEmpty}
-                  height={25}
-                  width={25}
-                  fill={theme.colors.white}
-                />
-                Compare Departments
-              </Button>
-            </S.AgencyHeaderButton>
-          )}
-          {showCloseButton && (
-            <S.AgencyHeaderButton>
-              <Button
-                variant="positive"
-                border={`2px solid ${theme.colors.primary}`}
-                {...ChartHeaderStyles.ButtonInlines}
-                onClick={() => toggleShowCompare()}
-              >
-                <ChartHeaderStyles.Icon
-                  icon={ICONS.close}
-                  height={25}
-                  width={25}
-                  fill={theme.colors.white}
-                />
-                Close
-              </Button>
-            </S.AgencyHeaderButton>
-          )}
+          <S.SubHeaderContentRow
+            flexDirection="row"
+            justifyContent="space-between"
+            breakpoint={phoneOnly}
+          >
+            <DataSubsetPicker
+              label="Year"
+              value={year}
+              onChange={handleYearSelect}
+              options={yearRange}
+              dropDown
+              labelOnLeft
+              dropdownWidth="100px"
+            />
+            {!showCloseButton && (
+              <S.AgencyHeaderButton>
+                <Button
+                  variant="positive"
+                  border={`2px solid ${theme.colors.primary}`}
+                  {...ChartHeaderStyles.ButtonInlines}
+                  onClick={() => toggleShowCompare()}
+                >
+                  <ChartHeaderStyles.Icon
+                    icon={showCompareDepartments ? ICONS.checkboxFilled : ICONS.checkboxEmpty}
+                    height={25}
+                    width={25}
+                    fill={theme.colors.white}
+                  />
+                  Compare Departments
+                </Button>
+              </S.AgencyHeaderButton>
+            )}
+            {showCloseButton && (
+              <S.AgencyHeaderButton>
+                <Button
+                  variant="positive"
+                  border={`2px solid ${theme.colors.primary}`}
+                  {...ChartHeaderStyles.ButtonInlines}
+                  onClick={() => toggleShowCompare()}
+                >
+                  <ChartHeaderStyles.Icon
+                    icon={ICONS.close}
+                    height={25}
+                    width={25}
+                    fill={theme.colors.white}
+                  />
+                  Close
+                </Button>
+              </S.AgencyHeaderButton>
+            )}
+          </S.SubHeaderContentRow>
         </S.AgencyHeader>
       )}
     </AnimatePresence>

--- a/frontend/src/Components/AgencyData/AgencyHeader.styled.js
+++ b/frontend/src/Components/AgencyData/AgencyHeader.styled.js
@@ -12,7 +12,7 @@ export const AgencyHeader = styled.div`
   padding: 0.5em 3em;
   position: sticky;
   top: 0;
-  z-index: 1000;
+  z-index: 9;
   background: ${(props) => props.theme.colors.white};
 
   @media (${smallerThanDesktop}) {
@@ -58,7 +58,8 @@ export const SubHeaderContentRow = styled.div`
   display: flex;
   flex: 1;
   flex-direction: ${(props) => props.flexDirection || 'row'};
-  @media (${smallerThanDesktop}) {
+  justify-content: ${(props) => props.justifyContent || 'flex-start'};
+  @media (${(props) => props.breakpoint || smallerThanDesktop}) {
     flex-direction: column;
   }
 `;

--- a/frontend/src/Components/AgencyData/AgencyHeader.styled.js
+++ b/frontend/src/Components/AgencyData/AgencyHeader.styled.js
@@ -10,6 +10,10 @@ import {
 export const AgencyHeader = styled.div`
   box-shadow: ${(props) => props.theme.shadows.depth1};
   padding: 0.5em 3em;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: ${(props) => props.theme.colors.white};
 
   @media (${smallerThanDesktop}) {
     padding: 0.5em 1em;

--- a/frontend/src/Components/AgencyData/CensusData.styled.js
+++ b/frontend/src/Components/AgencyData/CensusData.styled.js
@@ -30,7 +30,6 @@ export const CensusTitleMobile = styled.span`
 
 export const CensusDemographics = styled.div`
   display: flex;
-  flex: 1;
   flex-direction: column;
 
   @media (${phoneOnly}) {

--- a/frontend/src/Components/App.js
+++ b/frontend/src/Components/App.js
@@ -110,12 +110,14 @@ function App() {
                       </ChartStateProvider>
                     )}
                     {showCompare && !agencyId && (
-                      <div style={{ width: '50%', padding: 20 }}>
-                        <S.SubHeading>Search for Additional Departments to Compare</S.SubHeading>
-                        <DepartmentSearch
-                          onChange={(d) => updateAgencyId(d)}
-                          placeholder="Search for a police or sheriff's department..."
-                        />
+                      <div style={{ width: '50%' }}>
+                        <div style={{ padding: 20, position: 'sticky', top: 0 }}>
+                          <S.SubHeading>Search for Additional Departments to Compare</S.SubHeading>
+                          <DepartmentSearch
+                            onChange={(d) => updateAgencyId(d)}
+                            placeholder="Search for a police or sheriff's department..."
+                          />
+                        </div>
                       </div>
                     )}
                   </div>

--- a/frontend/src/Components/Charts/ChartSections/DataSubsetPicker/DataSubsetPicker.js
+++ b/frontend/src/Components/Charts/ChartSections/DataSubsetPicker/DataSubsetPicker.js
@@ -5,9 +5,18 @@ import * as S from './DataSubsetPicker.styled';
 import Dropdown from '../../../Elements/Dropdown/Dropdown';
 import { SIZES, COLORS, WEIGHTS } from '../../../../styles/StyledComponents/Typography';
 
-function DataSubsetPicker({ options, value, onChange, label, dropUp, dropDown }) {
+function DataSubsetPicker({
+  options,
+  value,
+  onChange,
+  label,
+  dropUp,
+  dropDown,
+  labelOnLeft,
+  dropdownWidth,
+}) {
   return (
-    <S.DataSubsetPicker>
+    <S.DataSubsetPicker labelOnLeft={labelOnLeft}>
       {label && (
         <S.Label size={SIZES[0]} color={COLORS[1]} weight={WEIGHTS[1]}>
           {label}
@@ -19,6 +28,7 @@ function DataSubsetPicker({ options, value, onChange, label, dropUp, dropDown })
         options={options}
         dropUp={dropUp}
         dropDown={dropDown}
+        width={dropdownWidth}
       />
     </S.DataSubsetPicker>
   );

--- a/frontend/src/Components/Charts/ChartSections/DataSubsetPicker/DataSubsetPicker.styled.js
+++ b/frontend/src/Components/Charts/ChartSections/DataSubsetPicker/DataSubsetPicker.styled.js
@@ -3,9 +3,9 @@ import { P } from '../../../../styles/StyledComponents/Typography';
 
 export const DataSubsetPicker = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: ${(props) => (props.labelOnLeft ? 'row' : 'column')};
+  column-gap: 10px;
+  align-items: ${(props) => (props.labelOnLeft ? 'center' : 'stretch')};
 `;
 
-export const Label = styled(P)`
-  margin-bottom: 0.5em;
-`;
+export const Label = styled(P)``;

--- a/frontend/src/Components/Elements/Alert/Alert.styled.js
+++ b/frontend/src/Components/Elements/Alert/Alert.styled.js
@@ -8,6 +8,7 @@ export const Alert = styled.div`
   margin-bottom: 20px;
   font-weight: bolder;
   font-size: 22px;
+  z-index: 11;
 `;
 
 export const CompareAlert = styled(Alert)`

--- a/frontend/src/Components/Elements/Dropdown/Dropdown.js
+++ b/frontend/src/Components/Elements/Dropdown/Dropdown.js
@@ -3,7 +3,7 @@ import { useTheme } from 'styled-components';
 import * as S from './Dropdown.styled';
 import { ICONS } from '../../../img/icons/Icon';
 
-export default function Dropdown({ value, onChange, options, dropUp, dropDown }) {
+export default function Dropdown({ value, onChange, options, dropUp, dropDown, width }) {
   const theme = useTheme();
   const inputRef = React.useRef();
   const containerRef = React.useRef();
@@ -41,7 +41,7 @@ export default function Dropdown({ value, onChange, options, dropUp, dropDown })
 
   return (
     <S.DropdownContainer>
-      <S.DropdownHeader ref={inputRef} onClick={() => setIsOpen(!isOpen)}>
+      <S.DropdownHeader ref={inputRef} onClick={() => setIsOpen(!isOpen)} width={width}>
         {value}
         <S.IconWrapper>
           <S.Icon icon={ICONS.chevronRight} width={25} height={25} fill={theme.colors.primary} />

--- a/frontend/src/Components/Elements/Dropdown/Dropdown.styled.js
+++ b/frontend/src/Components/Elements/Dropdown/Dropdown.styled.js
@@ -16,7 +16,7 @@ export const DropdownHeader = styled.div`
   color: ${(props) => props.theme.colors.text};
   background: ${(props) => props.theme.colors.white};
   min-height: 48px;
-  width: 260px;
+  width: ${(props) => props.width || '260px'};
 `;
 
 export const IconWrapper = styled.div`


### PR DESCRIPTION
Closes #335 

This PR makes the agency header sticky when scrolling and also makes it more compact by moving the "Compare Departments" button and the "Year" dropdown.

**Before**
<img width="1375" height="319" alt="2025-08-22_16-28" src="https://github.com/user-attachments/assets/b1023970-a9db-4a34-a526-12e75da9123c" />

**After**
<img width="1390" height="336" alt="2025-08-22_16-16" src="https://github.com/user-attachments/assets/d4173b1f-f57c-40b9-af64-5df9e184b26a" />

