### PR TITLE
Add tooltips for "Percentage of Stops Leading to Arrest by Stop Purpose Group".

### DIFF
--- a/frontend/src/Components/Charts/Arrest/Charts/PercentageOfSearchesForPurposeGroup.js
+++ b/frontend/src/Components/Charts/Arrest/Charts/PercentageOfSearchesForPurposeGroup.js
@@ -55,18 +55,21 @@ function PercentageOfSearchesForStopPurposeGroup(props) {
         };
         const data = {
           labels: Object.keys(colors),
-          datasets: [
-            {
-              axis: 'y',
-              label: 'All',
-              data: res.data.arrest_percentages.map((d) => d.data),
+          datasets: res.data.arrest_percentages.map((d, index) => {
+            const label =
+              d.stop_purpose === 'Regulatory and Equipment'
+                ? 'Regulatory Equipment'
+                : d.stop_purpose;
+            return {
+              label,
+              data: Array.from({ length: 3 }, (el, i) => (i === index ? d.data : el)),
               fill: false,
-              backgroundColor: Object.values(colors),
-              borderColor: Object.values(colors),
-              hoverBackgroundColor: Object.values(colors),
+              backgroundColor: colors[label],
+              borderColor: colors[label],
+              hoverBackgroundColor: colors[label],
               borderWidth: 1,
-            },
-          ],
+            };
+          }),
         };
         setArrestData(data);
       })
@@ -139,8 +142,8 @@ function PercentageOfSearchesForStopPurposeGroup(props) {
         <HorizontalBarChart
           title={graphTitle}
           data={arrestData}
-          displayLegend={false}
           tooltipLabelCallback={formatTooltipValue}
+          displayStopPurposeTooltips
           modalConfig={{
             tableHeader: graphTitle,
             tableSubheader: getBarChartModalSubHeading(
@@ -149,6 +152,7 @@ function PercentageOfSearchesForStopPurposeGroup(props) {
             agencyName,
             chartTitle: getBarChartModalSubHeading(graphTitle),
           }}
+          skipNull
         />
       </ChartContainer>
     </S.ChartSection>

--- a/frontend/src/Components/Charts/Arrest/Charts/PercentageOfStopsForPurposeGroup.js
+++ b/frontend/src/Components/Charts/Arrest/Charts/PercentageOfStopsForPurposeGroup.js
@@ -54,18 +54,21 @@ function PercentageOfStopsForStopPurposeGroup(props) {
         };
         const data = {
           labels: Object.keys(colors),
-          datasets: [
-            {
-              axis: 'y',
-              label: 'All',
-              data: res.data.arrest_percentages.map((d) => d.data),
+          datasets: res.data.arrest_percentages.map((d, index) => {
+            const label =
+              d.stop_purpose === 'Regulatory and Equipment'
+                ? 'Regulatory Equipment'
+                : d.stop_purpose;
+            return {
+              label,
+              data: Array.from({ length: 3 }, (el, i) => (i === index ? d.data : el)),
               fill: false,
-              backgroundColor: Object.values(colors),
-              borderColor: Object.values(colors),
-              hoverBackgroundColor: Object.values(colors),
+              backgroundColor: colors[label],
+              borderColor: colors[label],
+              hoverBackgroundColor: colors[label],
               borderWidth: 1,
-            },
-          ],
+            };
+          }),
         };
         setArrestData(data);
       })
@@ -138,8 +141,8 @@ function PercentageOfStopsForStopPurposeGroup(props) {
         <HorizontalBarChart
           title={graphTitle}
           data={arrestData}
-          displayLegend={false}
           tooltipLabelCallback={formatTooltipValue}
+          displayStopPurposeTooltips
           modalConfig={{
             tableHeader: graphTitle,
             tableSubheader: getBarChartModalSubHeading(
@@ -148,6 +151,7 @@ function PercentageOfStopsForStopPurposeGroup(props) {
             agencyName,
             chartTitle: getBarChartModalSubHeading(graphTitle),
           }}
+          skipNull
         />
       </ChartContainer>
     </S.ChartSection>

--- a/frontend/src/Components/NewCharts/HorizontalBarChart.js
+++ b/frontend/src/Components/NewCharts/HorizontalBarChart.js
@@ -38,6 +38,7 @@ export default function HorizontalBarChart({
   tickStyle = 'percent',
   stepSize = 0.5,
   modalConfig = {},
+  skipNull = false,
 }) {
   const tickCallback = function tickCallback(val) {
     if (tickStyle === 'percent') {
@@ -49,6 +50,7 @@ export default function HorizontalBarChart({
     responsive: true,
     maintainAspectRatio,
     indexAxis: 'y',
+    skipNull,
     scales: {
       x: {
         stacked: xStacked,


### PR DESCRIPTION
Closes #334 

This PR adds a legend with tooltips (shown on hover) to the "Percentage of Stops Leading to Arrest by Stop Purpose Group" chart in the Arrests page:

<img width="1115" height="779" alt="2025-08-22_16-35" src="https://github.com/user-attachments/assets/7a0620a7-5e93-4f60-9654-21ef255584f0" />
