### PR TITLE
Display the last reported stop date in 'Find a Stop' if no results are found.

### DIFF
--- a/frontend/src/Components/FindAStopResults/FindAStopResults.js
+++ b/frontend/src/Components/FindAStopResults/FindAStopResults.js
@@ -55,6 +55,7 @@ function FindAStopResults() {
 
   const [stops, setStops] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [lastReportedStop, setLastReportedStop] = useState(null);
 
   useEffect(() => {
     async function _fetchStops() {
@@ -63,6 +64,17 @@ function FindAStopResults() {
         const { data } = await axios.get(`${FIND_A_STOP_URL}${search}`);
         setStops(data.results);
         setLoading(false);
+        if (data.last_reported_stop) {
+          setLastReportedStop(
+            new Intl.DateTimeFormat('en-US', {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            }).format(new Date(data.last_reported_stop))
+          );
+        } else {
+          setLastReportedStop(null);
+        }
       } catch (e) {
         // eslint-disable-next-line no-console
         console.warn(e);
@@ -109,6 +121,7 @@ function FindAStopResults() {
                 this department
               </S.DeptLink>{' '}
               reported stops within your date range?
+              {lastReportedStop && ` Its last reported stop was on ${lastReportedStop}.`}
             </P>
           </S.NoResults>
         )}

--- a/nc/views/main.py
+++ b/nc/views/main.py
@@ -280,6 +280,19 @@ class DriverStopsViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filterset_class = DriverStopsFilter
 
+    def list(self, request, *args, **kwargs):
+        response = super().list(request, *args, **kwargs)
+        if not response.data["results"]:
+            # No stops were found. Add the agency's last_reported_stop to the
+            # response data
+            try:
+                agency = Agency.objects.get(id=request.GET.get("agency"))
+            except Agency.DoesNotExist:
+                pass
+            else:
+                response.data["last_reported_stop"] = agency.last_reported_stop
+        return response
+
 
 class StateFactsViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = StateFacts.objects.all()


### PR DESCRIPTION
Closes #337 

This PR adds the department's last reported stop date to the message that is displayed if no results are found in the "Find a Stop" page.
<img width="959" height="285" alt="2025-08-23_01-56" src="https://github.com/user-attachments/assets/c688e7a3-a281-4eb8-80a8-f71d8431ae77" />
