### PR TITLE
Adjust the age and date range when searching on 'Find a Stop'.

### DIFF
--- a/frontend/src/Components/FindAStopResults/FindAStopResults.js
+++ b/frontend/src/Components/FindAStopResults/FindAStopResults.js
@@ -56,6 +56,9 @@ function FindAStopResults() {
   const [stops, setStops] = useState([]);
   const [loading, setLoading] = useState(false);
   const [lastReportedStop, setLastReportedStop] = useState(null);
+  const [age, setAge] = useState(null);
+  const [startDate, setStartDate] = useState(null);
+  const [endDate, setEndDate] = useState(null);
 
   useEffect(() => {
     async function _fetchStops() {
@@ -75,6 +78,39 @@ function FindAStopResults() {
         } else {
           setLastReportedStop(null);
         }
+        if (data.start_date) {
+          setStartDate({
+            entered: new Intl.DateTimeFormat('en-US', {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            }).format(new Date(data.start_date.entered)),
+            adjusted: new Intl.DateTimeFormat('en-US', {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            }).format(new Date(data.start_date.adjusted)),
+          });
+        } else {
+          setStartDate(null);
+        }
+        if (data.end_date) {
+          setEndDate({
+            entered: new Intl.DateTimeFormat('en-US', {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            }).format(new Date(data.end_date.entered)),
+            adjusted: new Intl.DateTimeFormat('en-US', {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            }).format(new Date(data.end_date.adjusted)),
+          });
+        } else {
+          setEndDate(null);
+        }
+        setAge(data.age);
       } catch (e) {
         // eslint-disable-next-line no-console
         console.warn(e);
@@ -107,6 +143,22 @@ function FindAStopResults() {
             {stops.length === MAX_STOPS_RESULTS
               ? `Returned maximum number of results (${MAX_STOPS_RESULTS}). Try limiting your search`
               : `${stops.length} results found`}
+          </P>
+        )}
+        {!loading && age && (
+          <P size={SIZES[0]} color={COLORS[0]}>
+            You entered {age.entered} for Age but we used {age.adjusted[0]} - {age.adjusted[1]}{' '}
+            instead.
+          </P>
+        )}
+        {!loading && startDate && (
+          <P size={SIZES[0]} color={COLORS[0]}>
+            You entered {startDate.entered} for Start Date but we used {startDate.adjusted} instead.
+          </P>
+        )}
+        {!loading && endDate && (
+          <P size={SIZES[0]} color={COLORS[0]}>
+            You entered {endDate.entered} for End Date but we used {endDate.adjusted} instead.
           </P>
         )}
       </S.Heading>

--- a/nc/tests/api/test_basic_search.py
+++ b/nc/tests/api/test_basic_search.py
@@ -89,7 +89,7 @@ def test_age_adjusted(client, search_url, durham):
     age = 18
     # Create 5 stops with people within the expected age range
     people = [factories.PersonFactory(stop__agency=durham, age=i) for i in range(age - 2, age + 3)]
-    # Create 2 stops with people outside the expected age range and should not
+    # Create 2 stops with people outside the expected age range. These should not
     # be included in the search results
     factories.PersonFactory(stop__agency=durham, age=age - 3)
     factories.PersonFactory(stop__agency=durham, age=age + 3)

--- a/nc/tests/api/test_basic_search.py
+++ b/nc/tests/api/test_basic_search.py
@@ -1,3 +1,6 @@
+from datetime import timedelta
+
+import faker
 import pytest
 
 from rest_framework import status
@@ -6,6 +9,7 @@ from nc.models import RACE_CHOICES
 from nc.tests import factories
 
 pytestmark = pytest.mark.django_db
+fake = faker.Faker()
 
 
 RACE_VALUES = {v[0] for v in RACE_CHOICES}
@@ -42,6 +46,12 @@ def test_response_person_fields(client, search_url, durham):
         "stop_action": person.stop.get_action_display(),
     }
     assert result == expected
+    # 'age' should only be included if the user entered an age
+    assert "age" not in response.data
+    # 'start_date' should only be included if the user entered a start date
+    assert "start_date" not in response.data
+    # 'end_date' should only be included if the user entered an end date
+    assert "end_date" not in response.data
 
 
 @pytest.mark.django_db(databases=["traffic_stops_nc"])
@@ -55,3 +65,63 @@ def test_race_filtering(client, search_url, durham, race):
     person_ids = [r["person_id"] for r in response.data["results"]]
     assert p1.pk in person_ids, data
     assert p2.pk not in person_ids, data
+
+
+@pytest.mark.django_db(databases=["traffic_stops_nc"])
+def test_age_adjusted(client, search_url, durham):
+    """Ensure people aged + or - 2 years of the age the user entered are included
+    in search results.
+    """
+    age = 18
+    # Create 5 stops with people within the expected age range
+    people = [factories.PersonFactory(stop__agency=durham, age=i) for i in range(age - 2, age + 3)]
+    # Create 2 stops with people outside the expected age range and should not
+    # be included in the search results
+    factories.PersonFactory(stop__agency=durham, age=age - 3)
+    factories.PersonFactory(stop__agency=durham, age=age + 3)
+
+    response = client.get(search_url, data={"agency": durham.pk, "age": age}, format="json")
+
+    assert len(response.data["results"]) == len(people)
+    stop_ids = {stop["stop_id"] for stop in response.data["results"]}
+    assert {p.stop.stop_id for p in people} == stop_ids
+    # 'age' should be included in the response data, with the entered age and
+    # the adjusted age range
+    assert response.data["age"] == {"entered": age, "adjusted": (age - 2, age + 2)}
+
+
+@pytest.mark.django_db(databases=["traffic_stops_nc"])
+def test_stop_date_range_adjusted(client, search_url, durham):
+    """Ensure the date range entered by the user is adjusted such that the start_date
+    is 2 days earlier and end_date is 2 days later.
+    """
+    start_date = fake.past_date()
+    end_date = fake.past_date(start_date=start_date)
+    # Create some stops within the expected date range
+    dates = (
+        [start_date, end_date]
+        + [start_date - timedelta(d) for d in [1, 2]]
+        + [end_date + timedelta(d) for d in [1, 2]]
+    )
+    people = [factories.PersonFactory(stop__agency=durham, stop__date=d) for d in dates]
+    # Create 2 stops outside the expected date range. These should not be included
+    # in the search results
+    factories.PersonFactory(stop__agency=durham, stop__date=start_date - timedelta(3))
+    factories.PersonFactory(stop__agency=durham, stop__date=end_date + timedelta(3))
+
+    response = client.get(
+        search_url,
+        data={"agency": durham.pk, "stop_date_after": start_date, "stop_date_before": end_date},
+        format="json",
+    )
+
+    assert len(response.data["results"]) == len(people)
+    stop_ids = {stop["stop_id"] for stop in response.data["results"]}
+    assert {p.stop.stop_id for p in people} == stop_ids
+    # 'start_date' and 'end_date' should be included in the response data, with
+    # the entered and adjusted date for each
+    assert response.data["start_date"] == {
+        "entered": start_date,
+        "adjusted": start_date - timedelta(2),
+    }
+    assert response.data["end_date"] == {"entered": end_date, "adjusted": end_date + timedelta(2)}

--- a/nc/tests/api/test_timezones.py
+++ b/nc/tests/api/test_timezones.py
@@ -13,7 +13,7 @@ nc_timezone = pytz.timezone(settings.NC_TIME_ZONE)
 
 @pytest.fixture
 def july_person(durham):
-    stop_date = nc_timezone.localize(dt.datetime(2020, 7, 31, 20, 26))
+    stop_date = nc_timezone.localize(dt.datetime(2020, 7, 29, 20, 26))
     return factories.PersonFactory(stop__agency=durham, stop__date=stop_date)
 
 

--- a/nc/views/main.py
+++ b/nc/views/main.py
@@ -271,6 +271,21 @@ class DriverStopsViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filterset_class = DriverStopsFilter
 
+    def list(self, request, *args, **kwargs):
+        response = super().list(request, *args, **kwargs)
+        if response.data["results"]:
+            # If the user entered an age or date range, add the values entered
+            # and the adjusted values to the response, so they can be included
+            # in a message on the frontend
+            for field in ("age", "start_date", "end_date"):
+                adjusted = getattr(request, f"adjusted_{field}", None)
+                if adjusted:
+                    response.data[field] = {
+                        "entered": adjusted[0],
+                        "adjusted": adjusted[1],
+                    }
+        return response
+
 
 class StateFactsViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = StateFacts.objects.all()


### PR DESCRIPTION
Closes #338 

This PR adjusts the age and date range when searching on 'Find a Stop':
- when age is specified, include + or - 2 years to the age range;
- when start date is specified, include start date - 2 days to the date range;
- when end date is specified, include end date + 2 days to the date range.

A message is displayed on the frontend about the adjusted age or date range:

<img width="1275" height="782" alt="2025-08-25_22-05" src="https://github.com/user-attachments/assets/4d838402-1584-451e-b756-62934dc507b1" />
