### PR TITLE
Fix flaky search by reason test.

### DIFF
--- a/nc/tests/factories.py
+++ b/nc/tests/factories.py
@@ -3,6 +3,8 @@ import datetime
 import factory
 import factory.fuzzy
 
+from django.utils.timezone import localtime
+
 from nc import models
 
 
@@ -46,6 +48,8 @@ class StopFactory(factory.django.DjangoModelFactory):
         if extracted:
             day = 1 if self.date.month == 2 else self.date.day
             self.date = self.date.replace(year=extracted, day=day)
+            if localtime(self.date).year != extracted:
+                self.date += datetime.timedelta(1)
 
 
 class SearchFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
Closes #345 

This PR fixes the `AgencyTests.test_searches_by_reason` test, which would occasionally fail if `StopFactory` generated a `date` falling on 1st Jan and before 5am UTC. This would cause such stops to be grouped under the wrong year when a `StopSummary` is created, since the SQL for refreshing the view uses [`DATE_TRUNC('month', date AT TIME ZONE 'America/New_York')`](https://github.com/caktus/Traffic-Stops/blob/9dc7462249d849f45f58fc855f5cbea56e72237f/nc/models.py#L233) to extract a date.