### PR TITLE
Fix ValueError when computing likelihood of stop.

### DIFF
--- a/nc/tests/api/test_stop_search_rate.py
+++ b/nc/tests/api/test_stop_search_rate.py
@@ -349,6 +349,27 @@ class TestLikelihoodStopQuery:
         assert black_stop_rate_ratio == black_stop_rate / white_stop_rate
         assert round(black_stop_rate_ratio, 4) == 2.6923
 
+    def test_population_zero(self, rf, durham, year_2020):
+        """Ensure the stop_rate and stop_rate_ratio for a race are both 0 if the
+        population is 0.
+        """
+        NCCensusProfileFactory(acs_id="durham", race="Asian", population=0, year=year_2020.year)
+        NCCensusProfileFactory(acs_id="durham", race="White", population=1000, year=year_2020.year)
+        PersonFactory.create_batch(
+            size=17, race=DriverRace.ASIAN, stop__agency=durham, stop__date=year_2020
+        )
+        PersonFactory.create_batch(
+            size=26, race=DriverRace.WHITE, stop__agency=durham, stop__date=year_2020
+        )
+        StopSummary.refresh()
+        url = reverse_querystring(
+            "nc:likelihood-of-stops", args=[durham.id], query_kwargs={"year": year_2020.year}
+        )
+        df = likelihood_stop_query(request=rf.get(url), agency_id=durham.id)
+        asian_drivers = df[df["race"] == "Asian"]
+        assert asian_drivers.iloc[0]["stop_rate"] == 0
+        assert asian_drivers.iloc[0]["stop_rate_ratio"] == 0
+
 
 @pytest.mark.django_db(databases=["traffic_stops_nc"])
 class TestLikelihoodStopView:

--- a/nc/views/likelihood.py
+++ b/nc/views/likelihood.py
@@ -1,4 +1,5 @@
 import django_filters
+import numpy as np
 import pandas as pd
 
 from django.db.models import Avg, Sum
@@ -102,7 +103,9 @@ def likelihood_stop_query(request, agency_id, debug=True):
     )
     if not df_acs.empty:
         # Calculate rates
-        df["stop_rate"] = df["stops"] / df["population"]
+        # If population is 0 for a race, its stop_rate will be `inf`, which will
+        # cause a ValueError when serializing to JSON. Update it to 0 in such cases
+        df["stop_rate"] = (df["stops"] / df["population"]).replace(np.inf, 0)
         df["baseline_rate"] = df[df["race"] == "White"]["stop_rate"].iloc[0]
         df["stop_rate_ratio"] = df["stop_rate"] / df["baseline_rate"]
     else:

--- a/nc/views/likelihood.py
+++ b/nc/views/likelihood.py
@@ -103,8 +103,9 @@ def likelihood_stop_query(request, agency_id, debug=True):
     )
     if not df_acs.empty:
         # Calculate rates
-        # If population is 0 for a race, its stop_rate will be `inf`, which will
-        # cause a ValueError when serializing to JSON. Update it to 0 in such cases
+        # If stops is non-zero and population is 0 for a race, its stop_rate will
+        # be Infinity, which will cause a ValueError when serializing to JSON.
+        # Update it to 0 in such cases
         df["stop_rate"] = (df["stops"] / df["population"]).replace(np.inf, 0)
         df["baseline_rate"] = df[df["race"] == "White"]["stop_rate"].iloc[0]
         df["stop_rate_ratio"] = df["stop_rate"] / df["baseline_rate"]


### PR DESCRIPTION
Closes #353 

This PR fixes an error ([`ValueError: Out of range float values are not JSON compliant: inf`](https://caktus.sentry.io/issues/6839570166/?alert_rule_id=1668856&alert_type=issue&notification_uuid=c33a3ccc-24c2-4455-827b-36cff9ef2f77&project=5398612&referrer=slack)) that occurs when computing the likelihood of stops if the population for a race is zero according to the ACS data.