### PR TITLE
Update the message on adjusted age and date range in Find a Stop.

### DIFF
--- a/frontend/src/Components/FindAStopResults/FindAStopResults.js
+++ b/frontend/src/Components/FindAStopResults/FindAStopResults.js
@@ -56,9 +56,7 @@ function FindAStopResults() {
   const [stops, setStops] = useState([]);
   const [loading, setLoading] = useState(false);
   const [lastReportedStop, setLastReportedStop] = useState(null);
-  const [age, setAge] = useState(null);
-  const [startDate, setStartDate] = useState(null);
-  const [endDate, setEndDate] = useState(null);
+  const [extraResultsMessage, setExtraResultsMessage] = useState('');
 
   useEffect(() => {
     async function _fetchStops() {
@@ -78,39 +76,7 @@ function FindAStopResults() {
         } else {
           setLastReportedStop(null);
         }
-        if (data.start_date) {
-          setStartDate({
-            entered: new Intl.DateTimeFormat('en-US', {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric',
-            }).format(new Date(data.start_date.entered)),
-            adjusted: new Intl.DateTimeFormat('en-US', {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric',
-            }).format(new Date(data.start_date.adjusted)),
-          });
-        } else {
-          setStartDate(null);
-        }
-        if (data.end_date) {
-          setEndDate({
-            entered: new Intl.DateTimeFormat('en-US', {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric',
-            }).format(new Date(data.end_date.entered)),
-            adjusted: new Intl.DateTimeFormat('en-US', {
-              year: 'numeric',
-              month: 'short',
-              day: 'numeric',
-            }).format(new Date(data.end_date.adjusted)),
-          });
-        } else {
-          setEndDate(null);
-        }
-        setAge(data.age);
+        setExtraResultsMessage(data.extra_results_message || '');
       } catch (e) {
         // eslint-disable-next-line no-console
         console.warn(e);
@@ -142,23 +108,9 @@ function FindAStopResults() {
           <P size={SIZES[0]} color={COLORS[0]}>
             {stops.length === MAX_STOPS_RESULTS
               ? `Returned maximum number of results (${MAX_STOPS_RESULTS}). Try limiting your search`
-              : `${stops.length} results found`}
-          </P>
-        )}
-        {!loading && age && (
-          <P size={SIZES[0]} color={COLORS[0]}>
-            You entered {age.entered} for Age but we used {age.adjusted[0]} - {age.adjusted[1]}{' '}
-            instead.
-          </P>
-        )}
-        {!loading && startDate && (
-          <P size={SIZES[0]} color={COLORS[0]}>
-            You entered {startDate.entered} for Start Date but we used {startDate.adjusted} instead.
-          </P>
-        )}
-        {!loading && endDate && (
-          <P size={SIZES[0]} color={COLORS[0]}>
-            You entered {endDate.entered} for End Date but we used {endDate.adjusted} instead.
+              : `${stops.length} results found` +
+                (extraResultsMessage &&
+                  ` ${extraResultsMessage}. We show you extra results in case the officer made a mistake in their report or your search details had an error.`)}
           </P>
         )}
       </S.Heading>

--- a/nc/filters.py
+++ b/nc/filters.py
@@ -32,19 +32,21 @@ class DriverStopsFilter(filters.FilterSet):
     def filter_stop_date(self, queryset, name, value):
         start_date = value.start
         end_date = value.stop
+        adjusted_start_date = adjusted_end_date = None
         query = Q()
         if start_date:
             # Adjust it to 2 days earlier
             adjusted_start_date = start_date - timedelta(2)
             query &= Q(stop__date__gte=adjusted_start_date)
-            if self.request:
-                self.request.adjusted_start_date = start_date.date(), adjusted_start_date.date()
         if end_date:
             # Adjust it to 2 days later
             adjusted_end_date = end_date + timedelta(2)
             query &= Q(stop__date__lte=adjusted_end_date)
-            if self.request:
-                self.request.adjusted_end_date = end_date.date(), adjusted_end_date.date()
+        if self.request and (adjusted_start_date or adjusted_end_date):
+            self.request.adjusted_date_range = [
+                adjusted_start_date and adjusted_start_date.date(),
+                adjusted_end_date and adjusted_end_date.date(),
+            ]
         return queryset.filter(query)
 
     def filter_officer(self, queryset, name, value):
@@ -61,7 +63,7 @@ class DriverStopsFilter(filters.FilterSet):
         value = int(value)
         age_range = max(value - 2, 0), value + 2
         if self.request:
-            self.request.adjusted_age = value, age_range
+            self.request.adjusted_age = age_range
         return queryset.filter(age__gte=age_range[0], age__lte=age_range[1])
 
     class Meta:

--- a/nc/tests/api/test_basic_search.py
+++ b/nc/tests/api/test_basic_search.py
@@ -5,7 +5,7 @@ import pytest
 
 from rest_framework import status
 
-from nc.models import RACE_CHOICES
+from nc.models import RACE_CHOICES, Person
 from nc.tests import factories
 
 pytestmark = pytest.mark.django_db
@@ -48,12 +48,6 @@ def test_response_person_fields(client, search_url, durham):
     assert result == expected
     # 'last_reported_stop' should only be included if no matching stops were found
     assert "last_reported_stop" not in response.data
-    # 'age' should only be included if the user entered an age
-    assert "age" not in response.data
-    # 'start_date' should only be included if the user entered a start date
-    assert "start_date" not in response.data
-    # 'end_date' should only be included if the user entered an end date
-    assert "end_date" not in response.data
 
 
 @pytest.mark.django_db(databases=["traffic_stops_nc"])
@@ -81,61 +75,69 @@ def test_no_stops_found(client, search_url):
     assert response.data.get("last_reported_stop") == agency.last_reported_stop
 
 
+@pytest.mark.parametrize("search_age", [True, False])
+@pytest.mark.parametrize("search_start_date", [True, False])
+@pytest.mark.parametrize("search_end_date", [True, False])
 @pytest.mark.django_db(databases=["traffic_stops_nc"])
-def test_age_adjusted(client, search_url, durham):
-    """Ensure people aged + or - 2 years of the age the user entered are included
-    in search results.
+def test_stop_date_range_and_age_adjusted(
+    client, search_url, durham, search_age, search_start_date, search_end_date
+):
+    """Ensure the date range and age entered by the user is adjusted such that:
+    - age is up to 2 years younger or older
+    - start date is 2 days earlier
+    - end date is 2 days later
     """
     age = 18
-    # Create 5 stops with people within the expected age range
-    people = [factories.PersonFactory(stop__agency=durham, age=i) for i in range(age - 2, age + 3)]
-    # Create 2 stops with people outside the expected age range. These should not
-    # be included in the search results
-    factories.PersonFactory(stop__agency=durham, age=age - 3)
-    factories.PersonFactory(stop__agency=durham, age=age + 3)
-
-    response = client.get(search_url, data={"agency": durham.pk, "age": age}, format="json")
-
-    assert len(response.data["results"]) == len(people)
-    stop_ids = {stop["stop_id"] for stop in response.data["results"]}
-    assert {p.stop.stop_id for p in people} == stop_ids
-    # 'age' should be included in the response data, with the entered age and
-    # the adjusted age range
-    assert response.data["age"] == {"entered": age, "adjusted": (age - 2, age + 2)}
-
-
-@pytest.mark.django_db(databases=["traffic_stops_nc"])
-def test_stop_date_range_adjusted(client, search_url, durham):
-    """Ensure the date range entered by the user is adjusted such that the start_date
-    is 2 days earlier and end_date is 2 days later.
-    """
     start_date = fake.past_date()
     end_date = fake.past_date(start_date=start_date)
-    # Create some stops within the expected date range
+    # Create some stops within the expected date range and age range
     dates = (
         [start_date, end_date]
         + [start_date - timedelta(d) for d in [1, 2]]
         + [end_date + timedelta(d) for d in [1, 2]]
     )
-    people = [factories.PersonFactory(stop__agency=durham, stop__date=d) for d in dates]
-    # Create 2 stops outside the expected date range. These should not be included
-    # in the search results
-    factories.PersonFactory(stop__agency=durham, stop__date=start_date - timedelta(3))
-    factories.PersonFactory(stop__agency=durham, stop__date=end_date + timedelta(3))
+    people = [
+        factories.PersonFactory(
+            stop__agency=durham, stop__date=d, age=fake.random_int(age - 2, age + 2)
+        )
+        for d in dates
+    ]
+    # Create 2 stops outside the expected date range and age range
+    factories.PersonFactory(stop__agency=durham, stop__date=start_date - timedelta(3), age=age - 3)
+    factories.PersonFactory(stop__agency=durham, stop__date=end_date + timedelta(3), age=age + 3)
 
-    response = client.get(
-        search_url,
-        data={"agency": durham.pk, "stop_date_after": start_date, "stop_date_before": end_date},
-        format="json",
-    )
+    expected_results = Person.objects.filter(stop__agency=durham)
+    expected_results_message = ""
+    search_params = {"agency": durham.pk}
+    if search_age:
+        search_params["age"] = age
+        expected_results = expected_results.filter(age__gte=age - 2, age__lte=age + 2)
+        expected_results_message = f"with drivers aged {age - 2}-{age + 2}"
+    if search_start_date:
+        search_params["stop_date_after"] = start_date
+        used_start_date = start_date - timedelta(2)
+        expected_results = expected_results.filter(stop__date__gte=used_start_date)
+        if search_end_date:
+            expected_results_message += f" between {used_start_date:%B %d, %Y}"
+        else:
+            expected_results_message += f" after {used_start_date:%B %d, %Y}"
+    if search_end_date:
+        search_params["stop_date_before"] = end_date
+        used_end_date = end_date + timedelta(2)
+        expected_results = expected_results.filter(stop__date__lte=used_end_date)
+        if search_start_date:
+            expected_results_message += f" and {used_end_date:%B %d, %Y}"
+        else:
+            expected_results_message += f" before {used_end_date:%B %d, %Y}"
 
-    assert len(response.data["results"]) == len(people)
+    response = client.get(search_url, data=search_params, format="json")
+
+    assert len(response.data["results"]) == len(expected_results)
     stop_ids = {stop["stop_id"] for stop in response.data["results"]}
-    assert {p.stop.stop_id for p in people} == stop_ids
-    # 'start_date' and 'end_date' should be included in the response data, with
-    # the entered and adjusted date for each
-    assert response.data["start_date"] == {
-        "entered": start_date,
-        "adjusted": start_date - timedelta(2),
-    }
-    assert response.data["end_date"] == {"entered": end_date, "adjusted": end_date + timedelta(2)}
+    assert {p.stop.stop_id for p in expected_results} == stop_ids
+    # If the user entered an age and/or a date range, the 'extra_results_message'
+    # should be included in the response data
+    if expected_results_message:
+        assert response.data["extra_results_message"] == expected_results_message.strip()
+    else:
+        assert "extra_results_message" not in response.data

--- a/nc/views/main.py
+++ b/nc/views/main.py
@@ -274,16 +274,23 @@ class DriverStopsViewSet(viewsets.ReadOnlyModelViewSet):
     def list(self, request, *args, **kwargs):
         response = super().list(request, *args, **kwargs)
         if response.data["results"]:
-            # If the user entered an age or date range, add the values entered
-            # and the adjusted values to the response, so they can be included
-            # in a message on the frontend
-            for field in ("age", "start_date", "end_date"):
-                adjusted = getattr(request, f"adjusted_{field}", None)
-                if adjusted:
-                    response.data[field] = {
-                        "entered": adjusted[0],
-                        "adjusted": adjusted[1],
-                    }
+            # If the user entered an age and/or date range, add a message indicating
+            # the adjusted search parameters
+            message_parts = []
+            age_range = getattr(request, "adjusted_age", None)
+            date_range = getattr(request, "adjusted_date_range", None)
+            if age_range:
+                message_parts.append(f"with drivers aged {age_range[0]}-{age_range[1]}")
+            if date_range:
+                date_range = [i and i.strftime("%B %d, %Y") for i in date_range]
+                if all(date_range):
+                    message_parts.append(f"between {date_range[0]} and {date_range[1]}")
+                elif date_range[0]:
+                    message_parts.append(f"after {date_range[0]}")
+                else:
+                    message_parts.append(f"before {date_range[1]}")
+            if message_parts:
+                response.data["extra_results_message"] = " ".join(message_parts)
         else:
             # No stops were found. Add the agency's last_reported_stop to the
             # response data


### PR DESCRIPTION
Closes #359

This rephrases the message explaining search results when a user does a search in Find a Stop with an age and/or date range.

- [x] **If the user entered an age, start date, and end date:**
<img width="1169" height="71" alt="age_start_end" src="https://github.com/user-attachments/assets/fd919ad5-0cdb-4a9c-9f44-01ab9e7a6e71" />

- [x] **If the user entered an age and start date, but not end date:**
<img width="1134" height="75" alt="age_start" src="https://github.com/user-attachments/assets/63372738-18b0-479f-b007-fb33b62ffd0d" />

- [x] **If the user entered an age and end date, but not start date:**
<img width="1112" height="61" alt="age_end" src="https://github.com/user-attachments/assets/bf12c511-31ff-4b78-a586-ae2e15f6198b" />
