### PR TITLE
Fix incorrect Likelihood of Stop chart if some races have no stops.

### DIFF
--- a/frontend/src/Components/Charts/SearchRate/SearchRate.js
+++ b/frontend/src/Components/Charts/SearchRate/SearchRate.js
@@ -103,7 +103,13 @@ function SearchRate(props) {
           DEMOGRAPHICS_COLORS.other,
         ];
         const data = {
-          labels: ['Black', 'Hispanic', 'Asian', 'Native American', 'Other'],
+          labels: res.data.stop_percentages_races || [
+            'Black',
+            'Hispanic',
+            'Asian',
+            'Native American',
+            'Other',
+          ],
           datasets: [
             {
               axis: 'y',

--- a/nc/tests/api/test_stop_search_rate.py
+++ b/nc/tests/api/test_stop_search_rate.py
@@ -393,6 +393,7 @@ class TestLikelihoodStopView:
         # Stop rate ratio should be 0.6 for black drivers, or black drivers are
         # 60% more likely to be pulled over than white drivers
         assert data["stop_percentages"] == [0.62]
+        assert data["stop_percentages_races"] == ["Black"]
         table_data = data["table_data"]
         # Two rows for white and black drivers
         assert len(table_data) == 2
@@ -438,6 +439,7 @@ class TestLikelihoodStopView:
         assert response.status_code == 200
         data = response.json()
         assert data["stop_percentages"] == [1.69, -0.35]
+        assert data["stop_percentages_races"] == ["Black", "Asian"]
         table_data = data["table_data"]
         # Three rows for white, black, and asian drivers
         assert len(table_data) == 3
@@ -490,3 +492,4 @@ class TestLikelihoodStopView:
         # When no ACS data exists, stop_percentages should be empty
         assert data["stop_percentages"] == []
         assert data["table_data"] == []
+        assert "stop_percentages_races" not in data

--- a/nc/views/likelihood.py
+++ b/nc/views/likelihood.py
@@ -159,4 +159,11 @@ class LikelihoodStopView(APIView):
             "stop_percentages": stop_percentages,
             "table_data": table_data.to_dict(orient="records"),
         }
+
+        if stop_percentages and len(stop_percentages) < 5:
+            # We have stop percentages, but not for all races. Add the list of
+            # races with stop percentages to the response, so we'll know which
+            # ones to display in the chart on the frontend
+            data["stop_percentages_races"] = chart_df["race"]
+
         return Response(data=data, status=200)


### PR DESCRIPTION
Closes #361 

Only display the races for which we have stops data, to ensure the chart is correct. This also matches the table displayed in the View Data modal, which does not include races if they don't have stops.

For example, with no stops for Black and Native American races:
<img width="899" height="451" alt="2025-09-06_01-02" src="https://github.com/user-attachments/assets/8a461dc8-4d91-4b95-a20b-4fe825f84439" />

