### PR TITLE
Fix spacing between elements in the Agency header on mobile devices.

### DIFF
--- a/frontend/src/Components/AgencyData/CensusData.styled.js
+++ b/frontend/src/Components/AgencyData/CensusData.styled.js
@@ -42,6 +42,7 @@ export const CensusDemographicsMobile = styled.details`
 
   @media (${phoneOnly}) {
     display: block;
+    margin-bottom: 10px;
   }
 `;
 


### PR DESCRIPTION
Closes #355 

Fix the spacing between Census Demographics and the year dropdown on mobile devices.

|Before|After|
|:-|:-|
|<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/4b7f3036-736d-4561-8fa3-1e15f0dd8c5b" />|<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/6d499dc2-177a-492f-9d15-5edc8fc231b9" />|
