### PR TITLE
Upgrade the Base OS Image and Kubernetes to 1.33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,7 +129,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
 #   openssh-client -- for git over SSH
 #   sudo -- to run commands as superuser
 #   vim -- enhanced vi editor for commits
-ENV KUBE_CLIENT_VERSION="v1.32.6"
+ENV KUBE_CLIENT_VERSION="v1.33.0"
 ENV HELM_VERSION="3.18.3"
 ENV POSTGRESQL_CLIENT_VERSION="16"
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -37,7 +37,7 @@ cloudformation_stack_region: '{{ aws_region }}'
 cloudformation_stack_name: "{{ app_name }}-stack"
 cloudformation_stack_termination_protection: true
 cloudformation_stack_template_bucket: "aws-web-stacks-{{ app_name }}"
-cloudformation_stack_template_local_path: '{{ playbook_dir + "/stack/eks-no-nat.yml" }}'
+cloudformation_stack_template_local_path: '{{ playbook_dir + "/stack/eks-no-nat-2.4.0.yml" }}'
 cloudformation_stack_template_parameters:
   PrimaryAZ: "{{ aws_region }}a"
   SecondaryAZ: "{{ aws_region }}b"
@@ -61,6 +61,8 @@ cloudformation_stack_template_parameters:
   AssetsCloudFrontDomain: files.nccopwatch.org
   AssetsCloudFrontCertArn: arn:aws:acm:us-east-1:606178775542:certificate/379950bb-4b29-4308-8418-122674fe1076
   AssetsUseCloudFront: "true"
+  CustomEKSAMI: "" # Optional when CustomAMIImageType is set. Preferrably do not set as AWS will select best optimized image if CustomAMIImageType is set.
+  CustomAMIImageType: AL2023_x86_64_STANDARD
 cloudformation_stack_tags:
   Environment: "{{ app_name }}"
 
@@ -84,9 +86,9 @@ k8s_iam_users: [copelco]
 # Pin ingress-nginx and cert-manager to current versions so future upgrades of this
 # role will not upgrade these charts without your intervention:
 # https://github.com/kubernetes/ingress-nginx/releases
-k8s_ingress_nginx_chart_version: "4.12.3"
+k8s_ingress_nginx_chart_version: "4.13.0"
 # https://github.com/jetstack/cert-manager/releases
-k8s_cert_manager_chart_version: "v1.17.2"
+k8s_cert_manager_chart_version: "v1.18"
 # AWS only:
 # Use the newer load balancer type (NLB). DO NOT edit k8s_aws_load_balancer_type after
 # creating your Service.
@@ -97,7 +99,7 @@ k8s_aws_load_balancer_type: nlb
 # ----------------------------------------------------------------------------
 
 # New Relic Account: forwardjustice-team@caktusgroup.com
-k8s_newrelic_chart_version: "6.0.10"
+k8s_newrelic_chart_version: "6.0.11"
 k8s_newrelic_logging_enabled: true
 k8s_newrelic_license_key: !vault |
   $ANSIBLE_VAULT;1.1;AES256
@@ -113,7 +115,7 @@ k8s_install_descheduler: yes
 # You must set the k8s_descheduler_chart_version to match the Kubernetes
 # node version (0.23.x -> K8s 1.23.x); see:
 # https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
-k8s_descheduler_chart_version: v0.32.2
+k8s_descheduler_chart_version: v0.33.0
 # See values.yaml for options:
 # https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
 k8s_descheduler_release_values:

--- a/deploy/stack/eks-no-nat-2.4.0.yml
+++ b/deploy/stack/eks-no-nat-2.4.0.yml
@@ -50,6 +50,14 @@ Conditions:
     - !Equals
       - !Ref 'DatabaseReplication'
       - 'true'
+  UseCustomAMI: !Not
+    - !Equals
+      - !Ref 'CustomEKSAMI'
+      - ''
+  UseCustomAMIType: !Not
+    - !Equals
+      - !Ref 'CustomAMIImageType'
+      - ''
   EitherCacheCondition: !Or
     - !Condition 'UsingMemcached'
     - !Condition 'UsingRedis'
@@ -193,6 +201,15 @@ Metadata:
           - RedisNumCacheClusters
           - RedisSnapshotRetentionLimit
           - RedisAutomaticFailover
+      - Label:
+          default: Elastic Kubernetes Service (EKS)
+        Parameters:
+          - EnableEksEncryptionConfig
+          - EksPublicAccessCidrs
+          - EksClusterName
+          - CustomEKSAMI
+          - CustomAMIImageType
+          - EksClusterVersion
     ParameterLabels:
       AdministratorIPAddress:
         default: Admin IP Address
@@ -210,6 +227,10 @@ Metadata:
         default: Instance Type
       ContainerVolumeSize:
         default: Root Volume Size
+      CustomAMIImageType:
+        default: Custom AMI Image Type
+      CustomEKSAMI:
+        default: Custom EKS AMI
       CustomerManagedCmkArn:
         default: Customer managed key ARN
       DatabaseAllocatedStorage:
@@ -609,6 +630,14 @@ Parameters:
     Default: '20'
     Description: Size of instance EBS root volume (in GB)
     Type: Number
+  CustomAMIImageType:
+    Default: ''
+    Description: The image type to match the custom AMI. E.g., AL2023_x86_64_STANDARD, AL2_x86_64
+    Type: String
+  CustomEKSAMI:
+    Default: ''
+    Description: Custom AMI ID for EKS node group
+    Type: String
   CustomerManagedCmkArn:
     Default: ''
     Description: KMS CMK ARN to encrypt stack resources (except for public buckets).
@@ -1587,10 +1616,14 @@ Resources:
     DependsOn:
       - EksCluster
     Properties:
+      AmiType: !If
+        - UseCustomAMIType
+        - !Ref 'CustomAMIImageType'
+        - !Ref 'AWS::NoValue'
       ClusterName: !Ref 'EksCluster'
-      DiskSize: !Ref 'ContainerVolumeSize'
-      InstanceTypes:
-        - !Ref 'ContainerInstanceType'
+      LaunchTemplate:
+        Id: !Ref 'NodegroupLaunchTemplate'
+        Version: !GetAtt 'NodegroupLaunchTemplate.LatestVersionNumber'
       NodeRole: !GetAtt 'ContainerInstanceRole.Arn'
       ScalingConfig:
         DesiredSize: !Ref 'DesiredScale'
@@ -1602,6 +1635,29 @@ Resources:
       Tags:
         Key: Value
     Type: AWS::EKS::Nodegroup
+  NodegroupLaunchTemplate:
+    Properties:
+      LaunchTemplateData:
+        BlockDeviceMappings:
+          - DeviceName: /dev/xvda
+            Ebs:
+              DeleteOnTermination: true
+              Encrypted: !Ref 'UseAES256Encryption'
+              KmsKeyId: !If
+                - CmkArnCondition
+                - !Ref 'CustomerManagedCmkArn'
+                - !Ref 'AWS::NoValue'
+              VolumeSize: !Ref 'ContainerVolumeSize'
+              VolumeType: gp3
+        ImageId: !If
+          - UseCustomAMI
+          - !Ref 'CustomEKSAMI'
+          - !Ref 'AWS::NoValue'
+        InstanceType: !Ref 'ContainerInstanceType'
+        MetadataOptions:
+          HttpPutResponseHopLimit: 3
+          HttpTokens: required
+    Type: AWS::EC2::LaunchTemplate
   PrivateAssetsBucket:
     DeletionPolicy: Retain
     Properties:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dev = [
     "ipython>=8.32.0",
     "isort>=6.0.0",
     "kubernetes==32.*",
-    "kubernetes-validate~=1.32.0",
+    "kubernetes-validate~=1.33.0",
     "openshift>=0.13.2",
     "pre-commit>=4.1.0",
     "pytest>=8.3.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1003,7 +1003,7 @@ wheels = [
 
 [[package]]
 name = "kubernetes-validate"
-version = "1.32.0"
+version = "1.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-resources" },
@@ -1013,9 +1013,9 @@ dependencies = [
     { name = "referencing" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/63/d67b1df4971f3f869098ffb0895e9dc72612769fe3319068cf73cbbf6d18/kubernetes_validate-1.32.0.tar.gz", hash = "sha256:192837fdc2c191652501fe268dda34253dfacae0034505a51b0a3884d159361d", size = 7909598, upload-time = "2025-01-28T10:03:42.038Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/65/6ca340bd0acf560f81519e7fc8ae6fc4658872fbcd93158f8c3cf0b3b348/kubernetes_validate-1.33.1.tar.gz", hash = "sha256:53635bf66a5e04901209ae7f6aff0e8c19efa145cc9a90872344c92a31353a99", size = 8819459, upload-time = "2025-06-11T13:09:35.576Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/19/a45e98e8a462e402de2df5873e53c25fcd0dbfe067a861370be697ac1dea/kubernetes_validate-1.32.0-py3-none-any.whl", hash = "sha256:0d5610622bd9c8fdea67f114faf4dc71fda755c9640e58a1ad9f4bc13c8b7751", size = 16333406, upload-time = "2025-06-12T20:46:13.982Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/1c/79fa67f473225bf52c752cdd16c73c11127908a8adb190687633cf9f61d9/kubernetes_validate-1.33.1-py3-none-any.whl", hash = "sha256:fd910cff492ea32c85b8733fedd31dd0cf582925d3b3a3e73ceda1876f87bdcb", size = 18231087, upload-time = "2025-06-11T13:09:32.123Z" },
 ]
 
 [[package]]
@@ -1882,7 +1882,7 @@ dev = [
     { name = "ipython", specifier = ">=8.32.0" },
     { name = "isort", specifier = ">=6.0.0" },
     { name = "kubernetes", specifier = "==32.*" },
-    { name = "kubernetes-validate", specifier = "~=1.32.0" },
+    { name = "kubernetes-validate", specifier = "~=1.33.0" },
     { name = "openshift", specifier = ">=0.13.2" },
     { name = "pre-commit", specifier = ">=4.1.0" },
     { name = "pytest", specifier = ">=8.3.3" },


### PR DESCRIPTION
This PR replaced the base linux image version from Amazon Linux Version 2 to Amazon Linux Version 2023 (AL2023) on the nodes in the EKS cluster and upgrades Kubernetes to version 1.33.


**Ingress Nginx**
```
> helm -n ingress-nginx list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
ingress-nginx   ingress-nginx   12              2025-11-20 14:19:30.788298 -0500 EST    deployed        ingress-nginx-4.13.0    1.13.0 
```

**Cert Manager**
```
> helm -n cert-manager list                      
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
cert-manager    cert-manager    11              2025-11-20 14:20:38.33727 -0500 EST     deployed        cert-manager-v1.18.3    v1.18.3  
```

**Descheduler**
```
> helm -n kube-system list                      
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
descheduler     kube-system     14              2025-11-20 14:21:50.561958 -0500 EST    deployed        descheduler-0.33.0      0.33.0
```
**Cluster and pods version** 

<img width="1804" height="950" alt="Screenshot 2025-11-20 at 2 27 48 PM" src="https://github.com/user-attachments/assets/1c593571-3c02-48fb-89cf-0ed10ebf590d" />


Closes:
 - https://app.clickup.com/t/868fwj01w
