### PR TITLE
Upgrage Base Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ RUN set -ex \
     vim \
     " \
     && seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{} \
-    #&& apt-get update && apt-get -y install wget gnupg2 lsb-release \
     && apt-get update && apt-get -y upgrade && apt-get -y install wget gnupg2 lsb-release \
     && sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
     && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN set -ex \
     vim \
     " \
     && seq 1 8 | xargs -I{} mkdir -p /usr/share/man/man{} \
-    && apt-get update && apt-get -y install wget gnupg2 lsb-release \
+    #&& apt-get update && apt-get -y install wget gnupg2 lsb-release \
+    && apt-get update && apt-get -y upgrade && apt-get -y install wget gnupg2 lsb-release \
     && sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
     && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update && apt-get install -y --no-install-recommends $RUN_DEPS \
@@ -147,7 +148,6 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
     nodejs \
     openssh-client \
     postgresql-client-${POSTGRESQL_CLIENT_VERSION} \
-    psql \
     sudo \
     vim \
     " \


### PR DESCRIPTION
This PR ensures that the base image gets updated whenever a new image is built, it does so by adding `upgrade` to the apt-get base command. 
This fix came about because there was a big Open SSL vulnerability and this fix will address it, along with many other future security fixes. 

**Note:** `psql` was removed because it's already provided by `postgresql-client-16`.

**Test**

Ensure that the image builds successfully, something like: `docker build -t fj-caktus .`