### PR TITLE
Fix TypeError and NaN/inf errors in percentage and arrest-rate API views

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [main, develop, typeerror-nanerror]
+    branches: [main, develop]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, typeerror-nanerror]
 
 jobs:
   deploy:

--- a/nc/tests/api/test_arrests.py
+++ b/nc/tests/api/test_arrests.py
@@ -83,6 +83,20 @@ class TestArrests:
         assert response.status_code == 200
         assert response.json()["arrest_percentages"] == []
 
+    def test_no_searches_no_nan(self, client, durham):
+        """A stop with an arrest but no search must not produce NaN in search_arrest_rate"""
+        PersonFactory(
+            race=DriverRace.BLACK,
+            ethnicity=DriverEthnicity.NON_HISPANIC,
+            stop__agency=durham,
+            stop__driver_arrest=True,
+        )
+        StopSummary.refresh()
+        ContrabandSummary.refresh()
+        url = reverse("nc:arrests-percentage-of-searches", args=[durham.id])
+        response = client.get(url, data={}, format="json")
+        assert response.status_code == 200
+
     def test_year_range(self, client, durham):
         """Officer pages should only include stops from that officer"""
         PersonFactory(stop__date="2020-01-15", stop__agency=durham)

--- a/nc/tests/api/test_arrests.py
+++ b/nc/tests/api/test_arrests.py
@@ -97,6 +97,19 @@ class TestArrests:
         response = client.get(url, data={}, format="json")
         assert response.status_code == 200
 
+    def test_no_arrests_no_nan(self, client, durham):
+        """A stop with no arrest must not produce NaN in stop_arrest_rate (#arrest_count coalesce)"""
+        PersonFactory(
+            race=DriverRace.BLACK,
+            ethnicity=DriverEthnicity.NON_HISPANIC,
+            stop__agency=durham,
+            stop__driver_arrest=False,
+        )
+        StopSummary.refresh()
+        url = reverse("nc:arrests-percentage-of-stops", args=[durham.id])
+        response = client.get(url, data={}, format="json")
+        assert response.status_code == 200
+
     def test_year_range(self, client, durham):
         """Officer pages should only include stops from that officer"""
         PersonFactory(stop__date="2020-01-15", stop__agency=durham)

--- a/nc/tests/api/test_main.py
+++ b/nc/tests/api/test_main.py
@@ -9,7 +9,7 @@ from nc.tests.factories import PersonFactory, SearchFactory
 @pytest.mark.django_db(databases=["traffic_stops_nc"])
 class TestStopsByPercentage:
     def test_single_race_no_type_error(self, client, durham):
-        """A single-race dataset must not raise TypeError when calculating percentages (#392)"""
+        """A single-race dataset must not raise TypeError when calculating percentages"""
         PersonFactory(
             race=DriverRace.BLACK, ethnicity=DriverEthnicity.NON_HISPANIC, stop__agency=durham
         )
@@ -22,7 +22,7 @@ class TestStopsByPercentage:
 @pytest.mark.django_db(databases=["traffic_stops_nc"])
 class TestSearchesByPercentage:
     def test_single_race_no_type_error(self, client, durham):
-        """A single-race dataset must not raise TypeError when calculating search rates (#393)"""
+        """A single-race dataset must not raise TypeError when calculating search rates"""
         person = PersonFactory(
             race=DriverRace.BLACK, ethnicity=DriverEthnicity.NON_HISPANIC, stop__agency=durham
         )
@@ -32,8 +32,8 @@ class TestSearchesByPercentage:
         response = client.get(url)
         assert response.status_code == 200
 
-    def test_zero_stops_no_nan_in_response(self, client, durham):
-        """Zero total stops must not produce NaN values in the JSON response (#394)"""
+    def test_searches_no_nan_in_response(self, client, durham):
+        """Zero total stops must not produce NaN values in the JSON response"""
         person = PersonFactory(
             race=DriverRace.BLACK, ethnicity=DriverEthnicity.NON_HISPANIC, stop__agency=durham
         )
@@ -51,7 +51,7 @@ class TestSearchesByPercentage:
 @pytest.mark.django_db(databases=["traffic_stops_nc"])
 class TestSearchRate:
     def test_single_race_no_type_error(self, client, durham):
-        """A single-race dataset must not raise TypeError when calculating search rate (#395)"""
+        """A single-race dataset must not raise TypeError when calculating search rate"""
         person = PersonFactory(
             race=DriverRace.BLACK, ethnicity=DriverEthnicity.NON_HISPANIC, stop__agency=durham
         )

--- a/nc/tests/api/test_main.py
+++ b/nc/tests/api/test_main.py
@@ -46,3 +46,17 @@ class TestSearchesByPercentage:
         for dataset in response.json()["datasets"]:
             for value in dataset["data"]:
                 assert value == value, f"NaN found in dataset '{dataset['label']}'"
+
+
+@pytest.mark.django_db(databases=["traffic_stops_nc"])
+class TestSearchRate:
+    def test_single_race_no_type_error(self, client, durham):
+        """A single-race dataset must not raise TypeError when calculating search rate (#395)"""
+        person = PersonFactory(
+            race=DriverRace.BLACK, ethnicity=DriverEthnicity.NON_HISPANIC, stop__agency=durham
+        )
+        SearchFactory(stop=person.stop, person=person)
+        StopSummary.refresh()
+        url = reverse("nc:search-rate", args=[durham.id])
+        response = client.get(url)
+        assert response.status_code == 200

--- a/nc/tests/api/test_main.py
+++ b/nc/tests/api/test_main.py
@@ -1,0 +1,48 @@
+import pytest
+
+from django.urls import reverse
+
+from nc.models import DriverEthnicity, DriverRace, StopSummary
+from nc.tests.factories import PersonFactory, SearchFactory
+
+
+@pytest.mark.django_db(databases=["traffic_stops_nc"])
+class TestStopsByPercentage:
+    def test_single_race_no_type_error(self, client, durham):
+        """A single-race dataset must not raise TypeError when calculating percentages (#392)"""
+        PersonFactory(
+            race=DriverRace.BLACK, ethnicity=DriverEthnicity.NON_HISPANIC, stop__agency=durham
+        )
+        StopSummary.refresh()
+        url = reverse("nc:stops-by-percentage", args=[durham.id])
+        response = client.get(url)
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db(databases=["traffic_stops_nc"])
+class TestSearchesByPercentage:
+    def test_single_race_no_type_error(self, client, durham):
+        """A single-race dataset must not raise TypeError when calculating search rates (#393)"""
+        person = PersonFactory(
+            race=DriverRace.BLACK, ethnicity=DriverEthnicity.NON_HISPANIC, stop__agency=durham
+        )
+        SearchFactory(stop=person.stop, person=person)
+        StopSummary.refresh()
+        url = reverse("nc:searches-by-percentage", args=[durham.id])
+        response = client.get(url)
+        assert response.status_code == 200
+
+    def test_zero_stops_no_nan_in_response(self, client, durham):
+        """Zero total stops must not produce NaN values in the JSON response (#394)"""
+        person = PersonFactory(
+            race=DriverRace.BLACK, ethnicity=DriverEthnicity.NON_HISPANIC, stop__agency=durham
+        )
+        SearchFactory(stop=person.stop, person=person)
+        StopSummary.refresh()
+        url = reverse("nc:searches-by-percentage", args=[durham.id])
+        response = client.get(url)
+        assert response.status_code == 200
+        # All data values in all datasets must be finite numbers
+        for dataset in response.json()["datasets"]:
+            for value in dataset["data"]:
+                assert value == value, f"NaN found in dataset '{dataset['label']}'"

--- a/nc/views/arrests.py
+++ b/nc/views/arrests.py
@@ -1,4 +1,5 @@
 import django_filters
+import numpy as np
 import pandas as pd
 
 from django.db.models import Count, Q, Sum
@@ -96,10 +97,15 @@ def arrest_query(request, agency_id, group_by, debug=False):
         df = pd.DataFrame(
             qs, columns=list(qs.query.values_select) + list(qs.query.annotation_select)
         )
-    # Calculate rates; fillna(0) handles NaN (0/0 or x/None), replace handles inf (x/0)
-    _safe = [float("inf"), float("-inf")]
-    df["stop_arrest_rate"] = (df.arrest_count / df.stop_count).fillna(0).replace(_safe, 0)
-    df["search_arrest_rate"] = (df.arrest_count / df.search_count).fillna(0).replace(_safe, 0)
+    # SQL Sum() returns None (no matching rows) → object dtype in pandas 3.0; convert first
+    for col in ("stop_count", "search_count", "arrest_count"):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    df["stop_arrest_rate"] = (
+        (df.arrest_count / df.stop_count).fillna(0).replace([np.inf, -np.inf], 0)
+    )
+    df["search_arrest_rate"] = (
+        (df.arrest_count / df.search_count).fillna(0).replace([np.inf, -np.inf], 0)
+    )
     df["stop_without_arrest_count"] = df["stop_count"] - df["arrest_count"]
     # Only fill numeric columns to avoid TypeError with string columns
     numeric_cols = df.select_dtypes(include=["number"]).columns
@@ -163,11 +169,19 @@ def contraband_query(request, agency_id, group_by, debug=False):
     # Query stop counts
     stop_df = arrest_query(request, agency_id, group_by=("agency_id",))
     df["stop_count"] = stop_df.iloc[0]["stop_count"] if not stop_df.empty else 0
-    # Calculate rates
+    # SQL Count() returns integers; convert to float so division produces float64, not object
+    for col in ("contraband_count", "contraband_and_driver_arrest_count"):
+        df[col] = pd.to_numeric(df[col], errors="coerce")
     df["driver_contraband_arrest_rate"] = (
-        df.contraband_and_driver_arrest_count / df.contraband_count
+        (df.contraband_and_driver_arrest_count / df.contraband_count)
+        .fillna(0)
+        .replace([np.inf, -np.inf], 0)
     )
-    df["driver_stop_arrest_rate"] = df.contraband_and_driver_arrest_count / df.stop_count
+    df["driver_stop_arrest_rate"] = (
+        (df.contraband_and_driver_arrest_count / df.stop_count)
+        .fillna(0)
+        .replace([np.inf, -np.inf], 0)
+    )
     # Only fill numeric columns to avoid TypeError with string columns
     numeric_cols = df.select_dtypes(include=["number"]).columns
     df[numeric_cols] = df[numeric_cols].fillna(0)

--- a/nc/views/arrests.py
+++ b/nc/views/arrests.py
@@ -96,9 +96,10 @@ def arrest_query(request, agency_id, group_by, debug=False):
         df = pd.DataFrame(
             qs, columns=list(qs.query.values_select) + list(qs.query.annotation_select)
         )
-    # Calculate rates
-    df["stop_arrest_rate"] = df.arrest_count / df.stop_count
-    df["search_arrest_rate"] = df.arrest_count / df.search_count
+    # Calculate rates; fillna(0) handles NaN (0/0 or x/None), replace handles inf (x/0)
+    _safe = [float("inf"), float("-inf")]
+    df["stop_arrest_rate"] = (df.arrest_count / df.stop_count).fillna(0).replace(_safe, 0)
+    df["search_arrest_rate"] = (df.arrest_count / df.search_count).fillna(0).replace(_safe, 0)
     df["stop_without_arrest_count"] = df["stop_count"] - df["arrest_count"]
     # Only fill numeric columns to avoid TypeError with string columns
     numeric_cols = df.select_dtypes(include=["number"]).columns

--- a/nc/views/arrests.py
+++ b/nc/views/arrests.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 
 from django.db.models import Count, Q, Sum
-from django.db.models.functions import ExtractYear
+from django.db.models.functions import Coalesce, ExtractYear
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -88,8 +88,8 @@ def arrest_query(request, agency_id, group_by, debug=False):
     # Perform query with SQL aggregations
     qs = filter_set.qs.values(*group_by).annotate(
         stop_count=Sum("count"),
-        search_count=Sum("count", filter=Q(driver_searched=True)),
-        arrest_count=Sum("count", filter=Q(driver_arrest=True)),
+        search_count=Coalesce(Sum("count", filter=Q(driver_searched=True)), 0),
+        arrest_count=Coalesce(Sum("count", filter=Q(driver_arrest=True)), 0),
     )
     df = pd.DataFrame(qs)
     if df.empty:
@@ -97,9 +97,6 @@ def arrest_query(request, agency_id, group_by, debug=False):
         df = pd.DataFrame(
             qs, columns=list(qs.query.values_select) + list(qs.query.annotation_select)
         )
-    # SQL Sum() returns None (no matching rows) → object dtype in pandas 3.0; convert first
-    for col in ("stop_count", "search_count", "arrest_count"):
-        df[col] = pd.to_numeric(df[col], errors="coerce")
     df["stop_arrest_rate"] = (
         (df.arrest_count / df.stop_count).fillna(0).replace([np.inf, -np.inf], 0)
     )
@@ -169,9 +166,6 @@ def contraband_query(request, agency_id, group_by, debug=False):
     # Query stop counts
     stop_df = arrest_query(request, agency_id, group_by=("agency_id",))
     df["stop_count"] = stop_df.iloc[0]["stop_count"] if not stop_df.empty else 0
-    # SQL Count() returns integers; convert to float so division produces float64, not object
-    for col in ("contraband_count", "contraband_and_driver_arrest_count"):
-        df[col] = pd.to_numeric(df[col], errors="coerce")
     df["driver_contraband_arrest_rate"] = (
         (df.contraband_and_driver_arrest_count / df.contraband_count)
         .fillna(0)

--- a/nc/views/arrests.py
+++ b/nc/views/arrests.py
@@ -97,12 +97,9 @@ def arrest_query(request, agency_id, group_by, debug=False):
         df = pd.DataFrame(
             qs, columns=list(qs.query.values_select) + list(qs.query.annotation_select)
         )
-    df["stop_arrest_rate"] = (
-        (df.arrest_count / df.stop_count).fillna(0).replace([np.inf, -np.inf], 0)
-    )
-    df["search_arrest_rate"] = (
-        (df.arrest_count / df.search_count).fillna(0).replace([np.inf, -np.inf], 0)
-    )
+    df["stop_arrest_rate"] = df.arrest_count / df.stop_count
+    # search_count can be 0 (no searches) so inf is still possible
+    df["search_arrest_rate"] = (df.arrest_count / df.search_count).replace([np.inf, -np.inf], 0)
     df["stop_without_arrest_count"] = df["stop_count"] - df["arrest_count"]
     # Only fill numeric columns to avoid TypeError with string columns
     numeric_cols = df.select_dtypes(include=["number"]).columns
@@ -167,14 +164,10 @@ def contraband_query(request, agency_id, group_by, debug=False):
     stop_df = arrest_query(request, agency_id, group_by=("agency_id",))
     df["stop_count"] = stop_df.iloc[0]["stop_count"] if not stop_df.empty else 0
     df["driver_contraband_arrest_rate"] = (
-        (df.contraband_and_driver_arrest_count / df.contraband_count)
-        .fillna(0)
-        .replace([np.inf, -np.inf], 0)
-    )
-    df["driver_stop_arrest_rate"] = (
-        (df.contraband_and_driver_arrest_count / df.stop_count)
-        .fillna(0)
-        .replace([np.inf, -np.inf], 0)
+        df.contraband_and_driver_arrest_count / df.contraband_count
+    ).replace([np.inf, -np.inf], 0)
+    df["driver_stop_arrest_rate"] = (df.contraband_and_driver_arrest_count / df.stop_count).replace(
+        [np.inf, -np.inf], 0
     )
     # Only fill numeric columns to avoid TypeError with string columns
     numeric_cols = df.select_dtypes(include=["number"]).columns

--- a/nc/views/main.py
+++ b/nc/views/main.py
@@ -436,10 +436,9 @@ class AgencyTrafficStopsByPercentageView(APIView):
             for col in columns:
                 if col not in stops_df or year not in stops_df[col]:
                     continue
-                try:
-                    stops_df.loc[year, col] = float(stops_df[col][year] / total_stops_for_year)
-                except ZeroDivisionError:
-                    stops_df.loc[year, col] = 0
+                stops_df.loc[year, col] = (
+                    stops_df[col][year] / total_stops_for_year if total_stops_for_year else 0.0
+                )
 
         data = self.build_response(stops_df, unique_x_range)
         return Response(data=data, status=200)
@@ -1249,12 +1248,9 @@ class AgencySearchesByPercentageView(APIView):
                 if c in search_df and c in stops_df:
                     total_search += search_df[c][year] or 0
                     total_stop += stops_df[c][year] or 0
-                    try:
-                        search_df.loc[year, c] = float(search_df[c][year]) / float(
-                            stops_df[c][year]
-                        )
-                    except (ValueError, ZeroDivisionError):
-                        search_df.loc[year, c] = 0
+                    search_df.loc[year, c] = (
+                        search_df[c][year] / stops_df[c][year] if stops_df[c][year] else 0.0
+                    )
             search_df.loc[year, "Average"] = total_search / total_stop if total_stop else 0.0
 
         data = self.build_response(search_df, unique_x_range)

--- a/nc/views/main.py
+++ b/nc/views/main.py
@@ -1416,12 +1416,12 @@ class AgencySearchRateView(APIView):
         search_pivot_df = search_df.pivot(
             index="stop_purpose", columns="driver_race_comb", values="count"
         ).fillna(value=0)
-        search_df = pd.DataFrame(search_pivot_df)
+        search_df = search_pivot_df.astype(float)
 
         stop_pivot_df = stops_df.pivot(
             index="stop_purpose", columns="driver_race_comb", values="count"
         ).fillna(value=0)
-        stops_df = pd.DataFrame(stop_pivot_df)
+        stops_df = stop_pivot_df.astype(float)
 
         columns = ["Black", "Hispanic", "Asian", "Native American", "Other"]
         purpose_choices = {e.value: e.label for e in StopPurpose}

--- a/nc/views/main.py
+++ b/nc/views/main.py
@@ -426,7 +426,7 @@ class AgencyTrafficStopsByPercentageView(APIView):
         stop_pivot_df = stops_df.pivot(
             index=date_precision, columns="driver_race_comb", values="count"
         ).fillna(value=0)
-        stops_df = pd.DataFrame(stop_pivot_df)
+        stops_df = pd.DataFrame(stop_pivot_df).astype(float)
 
         columns = ["White", "Black", "Hispanic", "Asian", "Native American", "Other"]
         for year in unique_x_range:
@@ -1233,13 +1233,13 @@ class AgencySearchesByPercentageView(APIView):
         search_pivot_df = search_df.pivot(
             index=date_precision, columns="driver_race_comb", values="count"
         ).fillna(value=0)
-        search_df = pd.DataFrame(search_pivot_df)
-        search_df["Average"] = pd.Series([0] * len(unique_x_range))
+        search_df = pd.DataFrame(search_pivot_df).astype(float)
+        search_df["Average"] = pd.Series([0.0] * len(unique_x_range))
 
         stop_pivot_df = stops_df.pivot(
             index=date_precision, columns="driver_race_comb", values="count"
         ).fillna(value=0)
-        stops_df = pd.DataFrame(stop_pivot_df)
+        stops_df = pd.DataFrame(stop_pivot_df).astype(float)
 
         columns = ["White", "Black", "Hispanic", "Asian", "Native American", "Other"]
         for year in unique_x_range:
@@ -1255,7 +1255,7 @@ class AgencySearchesByPercentageView(APIView):
                         )
                     except (ValueError, ZeroDivisionError):
                         search_df.loc[year, c] = 0
-            search_df.loc[year, "Average"] = total_search / total_stop
+            search_df.loc[year, "Average"] = total_search / total_stop if total_stop else 0.0
 
         data = self.build_response(search_df, unique_x_range)
         return Response(data=data, status=200)

--- a/nc/views/main.py
+++ b/nc/views/main.py
@@ -426,7 +426,7 @@ class AgencyTrafficStopsByPercentageView(APIView):
         stop_pivot_df = stops_df.pivot(
             index=date_precision, columns="driver_race_comb", values="count"
         ).fillna(value=0)
-        stops_df = pd.DataFrame(stop_pivot_df).astype(float)
+        stops_df = stop_pivot_df.astype(float)
 
         columns = ["White", "Black", "Hispanic", "Asian", "Native American", "Other"]
         for year in unique_x_range:
@@ -1233,13 +1233,13 @@ class AgencySearchesByPercentageView(APIView):
         search_pivot_df = search_df.pivot(
             index=date_precision, columns="driver_race_comb", values="count"
         ).fillna(value=0)
-        search_df = pd.DataFrame(search_pivot_df).astype(float)
-        search_df["Average"] = pd.Series([0.0] * len(unique_x_range))
+        search_df = search_pivot_df.astype(float)
+        search_df["Average"] = 0.0
 
         stop_pivot_df = stops_df.pivot(
             index=date_precision, columns="driver_race_comb", values="count"
         ).fillna(value=0)
-        stops_df = pd.DataFrame(stop_pivot_df).astype(float)
+        stops_df = stop_pivot_df.astype(float)
 
         columns = ["White", "Black", "Hispanic", "Asian", "Native American", "Other"]
         for year in unique_x_range:


### PR DESCRIPTION
Fixes #392, #393, #394, and #396.

This was deployed to staging Sunday afternoon and I didn't see any new errors come in Monday morning.

All failures appear related to the upgrade to pandas 3.0 (#380):

* In pandas 2.x, assigning a `float` into an `int64` column via `.loc` would upcast the column to `float64`. In pandas 3.0 this silent upcasting was removed and raises `TypeError: Invalid value for dtype int64`. To fix, we call `.astype(float)` on the pivot result before any percentage assignments.
* `arrest_query()` calculates `search_arrest_rate = arrest_count / search_count`. `search_count` is `Sum("count", filter=Q(driver_searched=True))`, which PostgreSQL returns as `NULL` when no rows match the filter (i.e., the agency has no recorded searches). In both pandas 2.x and 3.0, pandas constructs an `object`-dtype column when `None` is present, so the division produces `NaN` as an object which then fails JSON serialization. This only affected agencies where zero searches were recorded. To fix, we use `Coalesce(Sum(..., filter=Q(...)), 0)` at the SQL level to always returns an integer.