### PR TITLE
Reduce Sentry traces sample rate and add agency cutoff count

### DIFF
--- a/deploy/group_vars/k8s.yml
+++ b/deploy/group_vars/k8s.yml
@@ -82,7 +82,7 @@ env_media_location: ""
 env_new_relic_app_name: "{{ k8s_namespace }}"
 env_new_relic_license_key: "{{ k8s_newrelic_license_key }}"
 env_sentry_dsn: https://8567ec420cf04ce3b7f4b82d5fff70f7@o168020.ingest.sentry.io/5398612
-env_sentry_traces_sample_rate: "1.0"
+env_sentry_traces_sample_rate: "0.1"
 env_nc_ftp_host: 199.90.195.21
 env_nc_ftp_user: TSTOPSuser
 env_nc_ftp_password: !vault |

--- a/nc/data/importer.py
+++ b/nc/data/importer.py
@@ -103,6 +103,7 @@ def run(url, destination=None, zip_path=None, min_stop_id=None, max_stop_id=None
             clear_cache=True,
             skip_agencies=False,
             skip_officers=True,
+            agency_cutoff_count=100,
         )
 
 


### PR DESCRIPTION
This PR reduces the Sentry traces sample rate in the k8s deployment config to lower observability overhead in production, and sets a default agency cutoff count in the NC data importer.

- Lower `env_sentry_traces_sample_rate` from 1.0 to 0.1 in k8s deployment group vars
- Add `agency_cutoff_count=100` argument to the NC importer run call