### PR TITLE
Add healthchecks.io success pings for ETL tasks

### DIFF
--- a/deploy/group_vars/k8s.yml
+++ b/deploy/group_vars/k8s.yml
@@ -108,6 +108,14 @@ env_email_use_tls: "true"
 # Basic auth
 env_basicauth_username: ""
 env_basicauth_password: ""
+# Healthchecks.io
+env_healthchecksio_ping_key: !vault |
+  $ANSIBLE_VAULT;1.1;AES256
+  65303535646162643463636161653130346534376564353037663839653762383538643136373534
+  6363663738373961366265643962326463333366346263620a323262353139303163383863343164
+  33346637643966366666313930323864623730613739666662383364343636666637643736376433
+  3964323235336533630a313132363337316239306264316632323138343835666566366136343931
+  34366636663033643863336136396264663237656231376263623462323362363733
 
 k8s_environment_variables:
   CONTAINER_IMAGE_TAG: "{{ k8s_container_image_tag }}"
@@ -157,6 +165,8 @@ k8s_environment_variables:
   NC_FTP_PASSWORD: "{{ env_nc_ftp_password }}"
   # Contact form
   CONTACT_US_EMAILS: "{{ env_contact_us_emails|join(':') }}"
+  # Healthchecks.io
+  HEALTHCHECKSIO_PING_KEY: "{{ env_healthchecksio_ping_key }}"
 
 # S3 bucket configuration:
 k8s_s3_region: "{{ aws_region }}"

--- a/traffic_stops/healthchecks.py
+++ b/traffic_stops/healthchecks.py
@@ -1,0 +1,81 @@
+"""Healthchecks.io integration for monitoring background tasks.
+
+This module provides utilities for pinging healthchecks.io to monitor
+the status of background tasks. It uses slug-based URLs which allow
+human-readable check identifiers.
+
+See: https://healthchecks.io/docs/http_api/
+"""
+
+import logging
+
+from enum import Enum
+
+import requests
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+class HealthcheckSignal(Enum):
+    """Signal types for healthchecks.io pinging API."""
+
+    SUCCESS = ""
+    START = "/start"
+    FAILURE = "/fail"
+    LOG = "/log"
+
+
+def ping_healthcheck(
+    slug: str, signal: HealthcheckSignal = HealthcheckSignal.SUCCESS, auto_provision: bool = True
+) -> bool:
+    """Ping a healthchecks.io check using slug-based URLs.
+
+    Args:
+        slug: The check's slug identifier (e.g., "sync-rpa-extracts")
+        signal: The signal type to send (default: SUCCESS)
+        auto_provision: If True, creates the check if it doesn't exist
+
+    Returns:
+        True if the ping was successful, False otherwise
+
+    Raises:
+        requests.RequestException: If the request fails and should be retried
+    """
+    if not settings.HEALTHCHECKSIO_PING_KEY:
+        logger.warning("healthcheck_ping_skipped reason=no_ping_key slug=%s", slug)
+        return False
+
+    # Prepend the environment name to the slug
+    slug = f"{settings.ENVIRONMENT}-{slug}"
+
+    # Build URL: https://hc-ping.com/<ping-key>/<slug>[/signal]
+    url = f"https://hc-ping.com/{settings.HEALTHCHECKSIO_PING_KEY}/{slug}{signal.value}"
+    params = {"create": "1"} if auto_provision else None
+
+    try:
+        response = requests.get(url, params=params, timeout=10.0)
+        response.raise_for_status()
+        logger.info(
+            "healthcheck_ping_success slug=%s signal=%s status_code=%s",
+            slug,
+            signal.name,
+            response.status_code,
+        )
+        return True
+    except requests.HTTPError as exc:
+        status_code = exc.response.status_code if exc.response else None
+        response_text = exc.response.text[:100] if exc.response else None
+        logger.warning(
+            "healthcheck_ping_failed slug=%s signal=%s status_code=%s response_text=%s",
+            slug,
+            signal.name,
+            status_code,
+            response_text,
+        )
+        return False
+    except requests.RequestException as exc:
+        logger.warning("healthcheck_ping_error slug=%s signal=%s error=%s", slug, signal.name, exc)
+        # Re-raise for retry in Celery task
+        raise

--- a/traffic_stops/settings/base.py
+++ b/traffic_stops/settings/base.py
@@ -286,6 +286,10 @@ CELERYBEAT_SCHEDULE = {
     },
 }
 
+# Healthchecks.io ping key for monitoring background tasks
+# https://healthchecks.io/docs/slug_urls/
+HEALTHCHECKSIO_PING_KEY = os.getenv("HEALTHCHECKSIO_PING_KEY", "")
+
 # If using Celery, tell it to obey our logging configuration.
 CELERYD_HIJACK_ROOT_LOGGER = False
 

--- a/traffic_stops/tests/test_healthchecks.py
+++ b/traffic_stops/tests/test_healthchecks.py
@@ -1,0 +1,15 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+from traffic_stops.healthchecks import HealthcheckSignal, ping_healthcheck
+
+
+class HealthcheckTests(SimpleTestCase):
+    @override_settings(HEALTHCHECKSIO_PING_KEY="")
+    @patch("traffic_stops.healthchecks.requests.get")
+    def test_ping_healthcheck_returns_false_when_ping_key_unset(self, mock_get):
+        result = ping_healthcheck(slug="import-dataset", signal=HealthcheckSignal.SUCCESS)
+
+        self.assertFalse(result)
+        mock_get.assert_not_called()

--- a/tsdata/tasks.py
+++ b/tsdata/tasks.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 
 from nc.data.importer import run as nc_run
 from traffic_stops.celery import app
+from traffic_stops.healthchecks import HealthcheckSignal, ping_healthcheck
 from tsdata.models import Dataset, Import
 
 logger = get_task_logger(__name__)
@@ -17,6 +18,43 @@ logger = get_task_logger(__name__)
 RUN_MAP = {
     settings.NC_KEY: nc_run,
 }
+
+
+@app.task(
+    bind=True,
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+    retry_backoff_max=300,
+    max_retries=5,
+)
+def ping_healthcheck_task(
+    self, slug: str, signal: str = "SUCCESS", auto_provision: bool = True
+) -> bool:
+    """Celery task to ping healthchecks.io with retry support.
+
+    Uses exponential backoff for transient network errors.
+
+    Args:
+        self: Celery task instance (bound)
+        slug: The check's slug identifier
+        signal: Signal name (SUCCESS, START, FAILURE, LOG)
+        auto_provision: If True, creates the check if it doesn't exist
+
+    Returns:
+        True if ping was successful, False otherwise
+    """
+    # Validate signal is a valid enum value
+    try:
+        signal_enum = HealthcheckSignal[signal]
+    except KeyError:
+        logger.error(
+            "ping_healthcheck_task.invalid_signal signal=%s valid_signals=%s",
+            signal,
+            list(HealthcheckSignal.__members__.keys()),
+        )
+        return False
+
+    return ping_healthcheck(slug=slug, signal=signal_enum, auto_provision=auto_provision)
 
 
 @app.task
@@ -47,6 +85,8 @@ def import_dataset(dataset_id):
         )
 
     compliance_report.delay(dataset_id)
+
+    ping_healthcheck_task.delay(slug="import-dataset", signal="SUCCESS", auto_provision=True)
 
 
 @app.task
@@ -88,6 +128,7 @@ def compliance_report(dataset_id):
             settings.DEFAULT_FROM_EMAIL,
             settings.COMPLIANCE_REPORT_LIST,
         )
+        ping_healthcheck_task.delay(slug="compliance-report", signal="SUCCESS", auto_provision=True)
         return
 
     csvfile = io.StringIO()
@@ -105,3 +146,5 @@ def compliance_report(dataset_id):
     )
     message.attach("report.csv", csvfile.getvalue(), "text/csv")
     message.send()
+
+    ping_healthcheck_task.delay(slug="compliance-report", signal="SUCCESS", auto_provision=True)

--- a/tsdata/tasks.py
+++ b/tsdata/tasks.py
@@ -86,7 +86,7 @@ def import_dataset(dataset_id):
 
     compliance_report.delay(dataset_id)
 
-    ping_healthcheck_task.delay(slug="import-dataset", signal="SUCCESS", auto_provision=True)
+    ping_healthcheck_task.delay(slug="import-dataset")
 
 
 @app.task
@@ -128,7 +128,7 @@ def compliance_report(dataset_id):
             settings.DEFAULT_FROM_EMAIL,
             settings.COMPLIANCE_REPORT_LIST,
         )
-        ping_healthcheck_task.delay(slug="compliance-report", signal="SUCCESS", auto_provision=True)
+        ping_healthcheck_task.delay(slug="compliance-report")
         return
 
     csvfile = io.StringIO()
@@ -147,4 +147,4 @@ def compliance_report(dataset_id):
     message.attach("report.csv", csvfile.getvalue(), "text/csv")
     message.send()
 
-    ping_healthcheck_task.delay(slug="compliance-report", signal="SUCCESS", auto_provision=True)
+    ping_healthcheck_task.delay(slug="compliance-report")

--- a/tsdata/tests/test_tasks.py
+++ b/tsdata/tests/test_tasks.py
@@ -18,6 +18,15 @@ from tsdata.tests.factories import DatasetFactory
 class ComplianceReportTests(TransactionTestCase):
     databases = "__all__"
 
+    def setUp(self):
+        super().setUp()
+        self.ping_delay_patcher = patch("tsdata.tasks.ping_healthcheck_task.delay")
+        self.ping_delay_patcher.start()
+
+    def tearDown(self):
+        self.ping_delay_patcher.stop()
+        super().tearDown()
+
     def test_all_agencies_good(self):
         for _i in range(3):
             agency = NCAgencyFactory()

--- a/tsdata/tests/test_tasks.py
+++ b/tsdata/tests/test_tasks.py
@@ -107,6 +107,4 @@ class ImportDatasetHealthcheckTests(TransactionTestCase):
             tasks.import_dataset(dataset.id)
 
         mock_compliance_delay.assert_called_once_with(dataset.id)
-        mock_ping_delay.assert_called_once_with(
-            slug="import-dataset", signal="SUCCESS", auto_provision=True
-        )
+        mock_ping_delay.assert_called_once_with(slug="import-dataset")

--- a/tsdata/tests/test_tasks.py
+++ b/tsdata/tests/test_tasks.py
@@ -2,6 +2,8 @@ import csv
 import datetime
 import io
 
+from unittest.mock import patch
+
 from django.core import mail
 from django.test import TransactionTestCase, override_settings
 from django.utils import timezone
@@ -79,4 +81,23 @@ class ComplianceReportTests(TransactionTestCase):
         )
         self.assertEqual(
             rows[2], {"id": str(agencies[4].id), "name": agencies[4].name, "last_reported_stop": ""}
+        )
+
+
+class ImportDatasetHealthcheckTests(TransactionTestCase):
+    databases = "__all__"
+
+    @patch("tsdata.tasks.ping_healthcheck_task.delay")
+    @patch("tsdata.tasks.compliance_report.delay")
+    def test_success_enqueues_healthcheck_success_ping(
+        self, mock_compliance_delay, mock_ping_delay
+    ):
+        dataset = DatasetFactory(state="nc")
+
+        with patch.dict(tasks.RUN_MAP, {dataset.state: lambda *_args, **_kwargs: None}):
+            tasks.import_dataset(dataset.id)
+
+        mock_compliance_delay.assert_called_once_with(dataset.id)
+        mock_ping_delay.assert_called_once_with(
+            slug="import-dataset", signal="SUCCESS", auto_provision=True
         )


### PR DESCRIPTION
This PR integrates Healthchecks.io to monitor periodic ETL tasks across deployment environments. It introduces a healthcheck helper and a retrying Celery task wrapper, then wires success-path pings into the dataset import and compliance report workflows.

Additionally, this change includes tests verifying the ping behavior and ensuring the system skips execution when no ping key is configured.

## Changes

* **Monitoring:** Added `traffic_stops.healthchecks` with slug-based ping support and a signal enum.
* **Task Integration:** Added `ping_healthcheck_task` with retry logic, using it in the `import_dataset` and `compliance_report` success paths.
* **Configuration:** Added `HEALTHCHECKSIO_PING_KEY` to Django settings and exposed it via Kubernetes environment variables.
* **Testing:** Added tests for task ping enqueue logic and no-op behavior when the ping key is unset.