### PR TITLE
Fix agency cutoff count to limit by index not stop count

### DIFF
--- a/nc/tasks.py
+++ b/nc/tasks.py
@@ -66,9 +66,9 @@ def prime_groups_cache(
         by_officer=by_officer, limit_to_agencies=limit_to_agencies
     )
     logger.info(f"Queuing {len(endpoint_groups):,} {kind} endpoint groups")
-    for endpoint_group in endpoint_groups:
-        if endpoint_group.num_stops <= cutoff_count:
-            logger.info(f"Stopping due to cutoff ({endpoint_group.num_stops=}, {cutoff_count=})")
+    for i, endpoint_group in enumerate(endpoint_groups):
+        if cutoff_count and i >= cutoff_count:
+            logger.info(f"Stopping due to cutoff ({i=}, {cutoff_count=})")
             break
         prime_group_cache.delay(**endpoint_group._asdict())
 

--- a/nc/tests/test_tasks.py
+++ b/nc/tests/test_tasks.py
@@ -1,0 +1,38 @@
+from collections import namedtuple
+from unittest.mock import patch
+
+import pytest
+
+from nc.tasks import prime_groups_cache
+
+EndpointGroup = namedtuple("EndpointGroup", ["agency_id", "num_stops"])
+
+
+def make_groups(n):
+    return [EndpointGroup(agency_id=i, num_stops=1000 - i) for i in range(n)]
+
+
+@pytest.mark.django_db
+class TestPrimeGroupsCache:
+    @patch("nc.tasks.prime_group_cache")
+    @patch("nc.prime_cache.get_agencies_and_officers")
+    def test_no_cutoff_queues_all(self, mock_get, mock_task):
+        mock_get.return_value = make_groups(10)
+        prime_groups_cache(cutoff_count=0)
+        assert mock_task.delay.call_count == 10
+
+    @patch("nc.tasks.prime_group_cache")
+    @patch("nc.prime_cache.get_agencies_and_officers")
+    def test_cutoff_limits_to_top_n(self, mock_get, mock_task):
+        mock_get.return_value = make_groups(10)
+        prime_groups_cache(cutoff_count=3)
+        assert mock_task.delay.call_count == 3
+        queued_ids = [c.kwargs["agency_id"] for c in mock_task.delay.call_args_list]
+        assert queued_ids == [0, 1, 2]
+
+    @patch("nc.tasks.prime_group_cache")
+    @patch("nc.prime_cache.get_agencies_and_officers")
+    def test_cutoff_larger_than_groups(self, mock_get, mock_task):
+        mock_get.return_value = make_groups(5)
+        prime_groups_cache(cutoff_count=100)
+        assert mock_task.delay.call_count == 5


### PR DESCRIPTION
The previous fix to reduce priming cache to just 100 top agencies didn't work. It was comparing num_stops (number of stops) against the cutoff threshold instead of limiting to the top N agencies by rank. Now uses index-based cutoff to correctly process only the top 100 agencies.

- Changed prime_groups_cache to use enumerated index for cutoff comparison
- Fixes off-by-one logic where all 344 agencies were still being queued
- Added comprehensive test coverage for cutoff behavior