### PR TITLE
Upgrade Kubernetes v1.33 to v1.35

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,8 +129,8 @@ RUN groupadd --gid $USER_GID $USERNAME \
 #   openssh-client -- for git over SSH
 #   sudo -- to run commands as superuser
 #   vim -- enhanced vi editor for commits
-ENV KUBE_CLIENT_VERSION="v1.33.0"
-ENV HELM_VERSION="3.18.3"
+ENV KUBE_CLIENT_VERSION="v1.35.0"
+ENV HELM_VERSION="4.2.0"
 ENV POSTGRESQL_CLIENT_VERSION="16"
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     --mount=type=cache,mode=0755,target=/root/.cache/pip \

--- a/deploy/group_vars/all.yml
+++ b/deploy/group_vars/all.yml
@@ -83,12 +83,8 @@ k8s_ci_vault_password_arn: arn:aws:secretsmanager:us-east-2:606178775542:secret:
 k8s_letsencrypt_email: admin@caktusgroup.com
 k8s_iam_users: [copelco]
 
-# Pin ingress-nginx and cert-manager to current versions so future upgrades of this
-# role will not upgrade these charts without your intervention:
-# https://github.com/kubernetes/ingress-nginx/releases
-k8s_ingress_nginx_chart_version: "4.14.1"
 # https://github.com/jetstack/cert-manager/releases
-k8s_cert_manager_chart_version: "v1.18"
+k8s_cert_manager_chart_version: "v1.20.2"
 k8s_cert_manager_solvers:
   - selector:
       # Use *dnsZones* (not dnsNames) to match on any subdomain. Note that individual
@@ -127,7 +123,7 @@ k8s_aws_load_balancer_type: nlb
 # ----------------------------------------------------------------------------
 
 # New Relic Account: forwardjustice-team@caktusgroup.com
-k8s_newrelic_chart_version: "6.0.11"
+k8s_newrelic_chart_version: "7.0.14"
 k8s_newrelic_logging_enabled: true
 k8s_newrelic_license_key: !vault |
   $ANSIBLE_VAULT;1.1;AES256
@@ -143,7 +139,7 @@ k8s_install_descheduler: yes
 # You must set the k8s_descheduler_chart_version to match the Kubernetes
 # node version (0.23.x -> K8s 1.23.x); see:
 # https://github.com/kubernetes-sigs/descheduler#compatibility-matrix
-k8s_descheduler_chart_version: v0.33.0
+k8s_descheduler_chart_version: v0.35.1
 # See values.yaml for options:
 # https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/values.yaml#L63
 k8s_descheduler_release_values:

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -2,7 +2,7 @@
 
 - src: https://github.com/caktus/ansible-role-django-k8s
   name: caktus.django-k8s
-  version: v1.12.1
+  version: v1.12.2
 
 - src: https://github.com/caktus/ansible-role-aws-web-stacks
   name: caktus.aws-web-stacks
@@ -10,7 +10,7 @@
 
 - src: https://github.com/caktus/ansible-role-k8s-web-cluster
   name: caktus.k8s-web-cluster
-  version: v1.11.0
+  version: v1.12.1
 
 - src: https://github.com/caktus/ansible-role-k8s-hosting-services
   name: caktus.k8s-hosting-services

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ readme = "README.rst"
 requires-python = "~=3.13.0"
 dependencies = [
     "boto==2.49.0",
-    "boto3>=1.40.13",
-    "botocore>=1.40.13",
+    "boto3~=1.43",
+    "botocore~=1.43.11",
     "brotli>=1.1.0",
     "celery>=5.5.0",
     "census>=0.8.24",
@@ -81,8 +81,8 @@ dev = [
     "invoke-kubesae>=0.1.0",
     "ipython>=8.32.0",
     "jupyterlab>=4.5.3",
-    "kubernetes==32.*",
-    "kubernetes-validate~=1.33.0",
+    "kubernetes==35.*",
+    "kubernetes-validate==1.35.*",
     "openshift>=0.13.2",
     "plotly>=6.5.2",
     "pre-commit>=4.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -161,7 +161,7 @@ wheels = [
 
 [[package]]
 name = "awscli"
-version = "1.44.25"
+version = "1.45.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
@@ -171,9 +171,9 @@ dependencies = [
     { name = "rsa" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/56/94b4a8f6134748d9d6b69d54f125dc2ab8fe54a18f7db140ef44c1dbd7d2/awscli-1.44.25.tar.gz", hash = "sha256:6b4d1027d85b4e6d910aee31b7e1637a1d69940ace0f1336d1e85179c695184a", size = 1888784, upload-time = "2026-01-26T20:35:33.196Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c5/4b61a02a26ced19f2fa876d66f9961fcea074ddf3d125dd8f9b4ca1e165a/awscli-1.45.36.tar.gz", hash = "sha256:81324cc9f1969843a4114ef4a1ebb91916aed63f6f330ab1daaf186b982a73dc", size = 1896881, upload-time = "2026-06-23T02:47:10.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/e2/737350110c36a43d4f6ce5723afedd7b1128234319a28580cd71cc437f27/awscli-1.44.25-py3-none-any.whl", hash = "sha256:3e988bb9e88dffa7f92ffd4c23b4fdd7832fb8c1174d076bbc8fc21403408413", size = 4641153, upload-time = "2026-01-26T20:35:30.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a4/f0d4e9c3a34979f15301caf634fbe79fbd0bf47139f6847478812d62943e/awscli-1.45.36-py3-none-any.whl", hash = "sha256:3adf2eaaf9297818c090257fc8a0747eadac733279544791ef9d076bcd20bb97", size = 4649727, upload-time = "2026-06-23T02:47:07.504Z" },
 ]
 
 [[package]]
@@ -235,30 +235,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.35"
+version = "1.43.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/a4/e70cc79e8f91836c06021c35507c843e5bc39a2020a85a6a27a492b50f78/boto3-1.42.35.tar.gz", hash = "sha256:edbfbfbadd419e65888166dd044786d4b731cf60abeb2301b73e775e154d7c5e", size = 112928, upload-time = "2026-01-26T20:35:37.524Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/9f/897287e955db0f50b12fd69ef45956e4fd2c7ddb48c736872f7ea2314443/boto3-1.43.36.tar.gz", hash = "sha256:587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28", size = 112690, upload-time = "2026-06-23T02:47:14.561Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/26/75b6301514c74c398207462086af6cfe2a875fd8700a6e508559bb1ed21a/boto3-1.42.35-py3-none-any.whl", hash = "sha256:4251bbac90e4a190680439973d9e9ed851e50292c10cd063c8bf0c365410ffe1", size = 140606, upload-time = "2026-01-26T20:35:35.398Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f1/274303f52483ecf199eae6f8d9b6f5951670397ee4d72c06cfd4eb644612/boto3-1.43.36-py3-none-any.whl", hash = "sha256:42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f", size = 140031, upload-time = "2026-06-23T02:47:13.178Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.42.35"
+version = "1.43.36"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/3d/339edff36a3c6617900ec9d7a1203ffe4e06ffee1e5bd71126e31cd59e30/botocore-1.42.35.tar.gz", hash = "sha256:40a6e0f16afe9e5d42e956f0b6d909869793fadb21780e409063601fc3d094b8", size = 14903745, upload-time = "2026-01-26T20:35:25.85Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/37/da9e7f6ca73ac73afd7f0bb7f238aa5daba35c081e98d7f48a7c399599c0/botocore-1.43.36.tar.gz", hash = "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205", size = 15625488, upload-time = "2026-06-23T02:47:03.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/b6/68f0aec79462852f367128dd8892e47176da46a787386d1730ec5bbbfb01/botocore-1.42.35-py3-none-any.whl", hash = "sha256:b89f527987691abbd1374c4116cc2711471ce48e6da502db17e92b17b2af8d47", size = 14581567, upload-time = "2026-01-26T20:35:23.346Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/19/934f81592527a3f7f9b943c893e334c721a4644948642bc33885d584e9ec/botocore-1.43.36-py3-none-any.whl", hash = "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d", size = 15313630, upload-time = "2026-06-23T02:46:59.327Z" },
 ]
 
 [[package]]
@@ -811,20 +811,6 @@ wheels = [
 ]
 
 [[package]]
-name = "google-auth"
-version = "2.48.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "pyasn1-modules" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522, upload-time = "2026-01-26T19:22:47.157Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499, upload-time = "2026-01-26T19:22:45.099Z" },
-]
-
-[[package]]
 name = "greenlet"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1331,13 +1317,11 @@ wheels = [
 
 [[package]]
 name = "kubernetes"
-version = "32.0.1"
+version = "35.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "durationpy" },
-    { name = "google-auth" },
-    { name = "oauthlib" },
     { name = "python-dateutil" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -1346,14 +1330,14 @@ dependencies = [
     { name = "urllib3" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/e8/0598f0e8b4af37cd9b10d8b87386cf3173cb8045d834ab5f6ec347a758b3/kubernetes-32.0.1.tar.gz", hash = "sha256:42f43d49abd437ada79a79a16bd48a604d3471a117a8347e87db693f2ba0ba28", size = 946691, upload-time = "2025-02-18T21:06:34.148Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/10/9f8af3e6f569685ce3af7faab51c8dd9d93b9c38eba339ca31c746119447/kubernetes-32.0.1-py2.py3-none-any.whl", hash = "sha256:35282ab8493b938b08ab5526c7ce66588232df00ef5e1dbe88a419107dc10998", size = 1988070, upload-time = "2025-02-18T21:06:31.391Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602, upload-time = "2026-01-16T01:05:25.991Z" },
 ]
 
 [[package]]
 name = "kubernetes-validate"
-version = "1.33.1"
+version = "1.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-resources" },
@@ -1363,9 +1347,9 @@ dependencies = [
     { name = "referencing" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f1/65/6ca340bd0acf560f81519e7fc8ae6fc4658872fbcd93158f8c3cf0b3b348/kubernetes_validate-1.33.1.tar.gz", hash = "sha256:53635bf66a5e04901209ae7f6aff0e8c19efa145cc9a90872344c92a31353a99", size = 8819459, upload-time = "2025-06-11T13:09:35.576Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/8b/35ae3142a373bc55746380e4f68e644e6c151ab1dc9f1646c0cb34504d57/kubernetes_validate-1.35.0.tar.gz", hash = "sha256:50a9e46da2c0471c282bb3138c7d785d29231f6f1b7bc2e68a611ab41b228326", size = 8822189, upload-time = "2026-02-06T23:58:17.015Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/1c/79fa67f473225bf52c752cdd16c73c11127908a8adb190687633cf9f61d9/kubernetes_validate-1.33.1-py3-none-any.whl", hash = "sha256:fd910cff492ea32c85b8733fedd31dd0cf582925d3b3a3e73ceda1876f87bdcb", size = 18231087, upload-time = "2025-06-11T13:09:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a8/1407781f65289dd1f19c73016a0a5271aadf5562ed0085c64130c3e49519/kubernetes_validate-1.35.0-py3-none-any.whl", hash = "sha256:768909f0cea1c7d77761c8fdea028c6aa553151dafeae099c453742ad3324b43", size = 18060252, upload-time = "2026-02-06T23:58:13.948Z" },
 ]
 
 [[package]]
@@ -1816,18 +1800,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1-modules"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2153,14 +2125,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.16.0"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
 ]
 
 [[package]]
@@ -2491,8 +2463,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "boto", specifier = "==2.49.0" },
-    { name = "boto3", specifier = ">=1.40.13" },
-    { name = "botocore", specifier = ">=1.40.13" },
+    { name = "boto3", specifier = "~=1.43" },
+    { name = "botocore", specifier = "~=1.43.11" },
     { name = "brotli", specifier = ">=1.1.0" },
     { name = "celery", specifier = ">=5.5.0" },
     { name = "census", specifier = ">=0.8.24" },
@@ -2533,8 +2505,8 @@ dev = [
     { name = "invoke-kubesae", specifier = ">=0.1.0" },
     { name = "ipython", specifier = ">=8.32.0" },
     { name = "jupyterlab", specifier = ">=4.5.3" },
-    { name = "kubernetes", specifier = "==32.*" },
-    { name = "kubernetes-validate", specifier = "~=1.33.0" },
+    { name = "kubernetes", specifier = "==35.*" },
+    { name = "kubernetes-validate", specifier = "==1.35.*" },
     { name = "openshift", specifier = ">=0.13.2" },
     { name = "plotly", specifier = ">=6.5.2" },
     { name = "pre-commit", specifier = ">=4.1.0" },


### PR DESCRIPTION
This PR updates requirements to work with K8s version `1.35.x`.

**Traefik**
```
> helm -n traefik list
NAME    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART           APP VERSION
traefik traefik         3               2026-06-23 11:58:00.804688 -0400 EDT    deployed        traefik-40.2.0  v3.7.1    
```

**Cert Manager**
```
> helm -n cert-manager list                      
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
cert-manager    cert-manager    15              2026-06-23 11:54:44.913452 -0400 EDT    deployed        cert-manager-v1.20.2    v1.20.2  
```

**New Relic**
```
> helm -n newrelic list
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
newrelic-bundle newrelic        7               2026-06-15 13:47:20.037975 -0400 EDT    deployed        nri-bundle-7.0.19 
```

**Descheduler**
```
> helm -n kube-system list                
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                   APP VERSION
newrelic-bundle newrelic        12              2026-06-23 12:00:02.667617 -0400 EDT    deployed        nri-bundle-7.0.14    
```

**Helm and Kube Client upgrade and tests performed**

I took down my docker image and rebuilt without cache. 

Then:
```
# Ensure docker image still builds successfully
> docker build -t tf:latest .

# Verify new K8s version
 > docker run --rm tf:latest kubectl version --client                               
 
Client Version: v1.35.0
Kustomize Version: v5.7.1


# Verify new Helm version
> docker run --rm tf:latest helm version --short                                                        
v4.2.0+g0646808
```

**Cluster and nodes version** 
<img width="1810" height="947" alt="Screenshot 2026-06-23 at 1 39 08 PM" src="https://github.com/user-attachments/assets/ec4dcaa7-87b9-4b97-a065-7aa2af38c561" />

