### PR TITLE
Implement sub-threshold agencies audit and toggle on disparity map

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   push:
-    branches: [main, develop, 3973-likelihood-map2]
+    branches: [main, develop, 410-sub-threshold-agencies]
 
 jobs:
   deploy:

--- a/nc/notebooks/2025-11-likelihood-of-stops-comparison/likelihood-of-stop-comparison-v3.py
+++ b/nc/notebooks/2025-11-likelihood-of-stops-comparison/likelihood-of-stop-comparison-v3.py
@@ -47,6 +47,8 @@ with app.setup(hide_code=True):
 
     django.setup()
 
+    from django.db.models import Q  # noqa
+
     from nc.models import AgencyLikelihoodStatus, DriverRace  # noqa
     from nc.views.likelihood import (
         active_small_population_agencies,
@@ -270,12 +272,7 @@ def map_section_header(mo):
 
 
 @app.cell
-def sheriff_choropleth_map(
-    df_agency: pd.DataFrame,
-    mo,
-    race_dropdown,
-    year_label,
-):
+def sheriff_choropleth_map(mo, race_dropdown, selected_year, year_label):
     """Render a choropleth map of stop rate ratios for sheriff agencies by county."""
     simplified_geojson_path = django_project_dir / Path(
         "nc/data/North_Carolina_State_and_County_Boundary_Polygons_simplified.geojson"
@@ -284,28 +281,87 @@ def sheriff_choropleth_map(
 
     _map_race_sheriff = race_dropdown.value or DriverRace.BLACK.label
 
-    sheriff_df = df_agency[
-        df_agency["group_name"].str.contains("Sheriff")
-        & (df_agency["driver_race"] == _map_race_sheriff)
-    ].copy()
-    sheriff_df["fips3"] = sheriff_df["census_profile_id"].str[-3:]
+    # Pull all sheriff rows for the selected race, including non-active statuses,
+    # so we can distinguish counties excluded by a census population threshold
+    # from counties that simply never reported any stop data.
+    _sheriff_all = likelihood_comparison(
+        level="agency",
+        year=selected_year,
+        status=None,
+        query=Q(group_name__icontains="Sheriff"),
+    )
+    if not _sheriff_all.empty:
+        _sheriff_all = _sheriff_all[_sheriff_all["driver_race"] == _map_race_sheriff].copy()
+        _sheriff_all["fips3"] = _sheriff_all["census_profile_id"].str[-3:]
+    else:
+        # Guarantee the columns referenced below exist even with no data so the
+        # merges and status filters don't raise on an empty (columnless) frame.
+        _sheriff_all = pd.DataFrame(
+            columns=[
+                "fips3",
+                "status",
+                "group_name",
+                "driver_race",
+                "population",
+                "total_population",
+                "stops",
+                "total_stops",
+                "stop_rate",
+                "baseline_rate",
+                "stop_rate_ratio",
+                "times_likely",
+            ]
+        )
 
-    # Build full county DataFrame so missing counties render as gray
+    # Active sheriff agencies drive the colored choropleth; the sheriff table
+    # below continues to summarize these.
+    sheriff_df = (
+        _sheriff_all[_sheriff_all["status"] == AgencyLikelihoodStatus.ACTIVE].copy()
+        if not _sheriff_all.empty
+        else _sheriff_all
+    )
+
+    # Counties excluded by a census population threshold (county < 10,000
+    # residents, or the selected race ≤ 100 residents) get a distinct color so
+    # they read as "below threshold" rather than "failed to report".
+    _threshold_statuses = [
+        AgencyLikelihoodStatus.SMALL_POPULATION,
+        AgencyLikelihoodStatus.SMALL_RACE_POPULATION,
+    ]
+    below_threshold_df = (
+        _sheriff_all[_sheriff_all["status"].isin(_threshold_statuses)].copy()
+        if not _sheriff_all.empty
+        else _sheriff_all
+    )
+
+    # Build full county DataFrame so every county falls into exactly one layer.
     all_fips = [
         (f["properties"]["FIPS"], f["properties"]["County"]) for f in simplified_geojson["features"]
     ]
     all_counties_df = pd.DataFrame(all_fips, columns=["fips3", "county_name"])
-    full_df = all_counties_df.merge(
+
+    data_df = all_counties_df.merge(
         sheriff_df[["fips3", "times_likely", "group_name", "stops", "population"]],
+        on="fips3",
+        how="inner",
+    )
+    _data_fips = set(data_df["fips3"])
+
+    _below_fips = (
+        set(below_threshold_df["fips3"]) - _data_fips if not below_threshold_df.empty else set()
+    )
+    below_df = all_counties_df[all_counties_df["fips3"].isin(_below_fips)].merge(
+        below_threshold_df[["fips3", "group_name"]].drop_duplicates("fips3"),
         on="fips3",
         how="left",
     )
-    missing_df = full_df[full_df["times_likely"].isna()]
-    data_df = full_df[full_df["times_likely"].notna()]
+
+    _covered_fips = _data_fips | _below_fips
+    missing_df = all_counties_df[~all_counties_df["fips3"].isin(_covered_fips)]
 
     fig_map = go.Figure()
 
-    # Gray base layer for counties without sheriff data
+    # Gray base layer for counties that never reported sheriff stop data
     fig_map.add_trace(
         go.Choropleth(
             geojson=simplified_geojson,
@@ -315,15 +371,38 @@ def sheriff_choropleth_map(
             colorscale=[[0, "#cccccc"], [1, "#cccccc"]],
             customdata=missing_df[["county_name"]].values,
             showscale=False,
-            hovertemplate="<b>%{customdata[0]} County</b><br>No data available.<br>Requires county ≥ 10k residents and selected race ≥ 100 residents.<extra></extra>",
-            name="No Data",
+            hovertemplate="<b>%{customdata[0]} County</b><br>No stop data reported.<extra></extra>",
+            name="Failed to report",
             showlegend=True,
             marker_line_color="white",
             marker_line_width=0.5,
         )
     )
 
-    # Data layer for counties with sheriff data
+    # Distinct layer for counties excluded by a census population threshold
+    if not below_df.empty:
+        fig_map.add_trace(
+            go.Choropleth(
+                geojson=simplified_geojson,
+                locations=below_df["fips3"],
+                z=[0] * len(below_df),
+                featureidkey="properties.FIPS",
+                colorscale=[[0, "#8e6fb0"], [1, "#8e6fb0"]],
+                customdata=below_df[["county_name"]].values,
+                showscale=False,
+                hovertemplate=(
+                    "<b>%{customdata[0]} County</b><br>Below population threshold.<br>"
+                    "Requires county ≥ 10k residents and selected race ≥ 100 residents."
+                    "<extra></extra>"
+                ),
+                name="Below population threshold",
+                showlegend=True,
+                marker_line_color="white",
+                marker_line_width=0.5,
+            )
+        )
+
+    # Data layer for counties with active sheriff data
     fig_map.add_trace(
         go.Choropleth(
             geojson=simplified_geojson,
@@ -554,9 +633,9 @@ def police_agency_disparity_map(
     _fig_disparity.update_layout(height=650, margin={"r": 0, "t": 40, "l": 0, "b": 0})
 
     # Overlay sub-threshold agencies as hollow markers so voluntary reporters are
-    # visually distinct from active agencies while sharing the disparity colors.
+    # visually distinct from active agencies. A solid black outline is used (rather
+    # than the disparity colors) so these markers are not color-coded by disparity.
     if not _small_pop_df.empty:
-        _marker_colors = _small_pop_df["disparity_category"].map(_DISPARITY_COLORS)
         _fig_disparity.add_trace(
             go.Scattergeo(
                 lat=_small_pop_df["latitude"],
@@ -575,7 +654,7 @@ def police_agency_disparity_map(
                 marker=dict(
                     size=10,
                     color="rgba(255, 255, 255, 0)",
-                    line=dict(width=2, color=_marker_colors),
+                    line=dict(width=2, color="black"),
                 ),
             )
         )
@@ -648,7 +727,8 @@ def sub_threshold_audit_section_header(mo):
     Some of these smaller departments voluntarily submit traffic stop data.
 
     The table below lists non-sheriff agencies under the threshold that recorded
-    at least one stop in the most recent data year, with each agency's total
+    at least one stop in the selected data year (from the sidebar **Year**
+    filter; "All" falls back to the most recent year), with each agency's total
     population and total stops. Use it to gauge the scope and data quality of
     voluntary reporting before investing in front-end visibility.
     """)
@@ -656,9 +736,12 @@ def sub_threshold_audit_section_header(mo):
 
 
 @app.cell
-def sub_threshold_audit(mo):
+def sub_threshold_audit(mo, selected_year):
     """List sub-threshold agencies that are actively reporting stop data."""
-    _audit_year = available_likelihood_years()[0]
+    # active_small_population_agencies() needs a concrete year. When the sidebar
+    # Year filter is set to "All" (selected_year is None), fall back to the most
+    # recent available year so the audit still renders.
+    _audit_year = selected_year if selected_year else available_likelihood_years()[0]
     _audit_df = active_small_population_agencies(year=_audit_year)
 
     _display_df = _audit_df.rename(
@@ -669,11 +752,12 @@ def sub_threshold_audit(mo):
         }
     )[["Agency", "Total population", "Total stops"]]
 
+    _year_note = "" if selected_year else " (most recent year; Year filter set to All)"
     mo.vstack(
         [
             mo.md(
                 f"**{len(_audit_df)}** sub-threshold non-sheriff agencies actively "
-                f"reported traffic stops in **{_audit_year}**."
+                f"reported traffic stops in **{_audit_year}**{_year_note}."
             ),
             mo.ui.table(_display_df, selection=None),
         ]

--- a/nc/notebooks/2025-11-likelihood-of-stops-comparison/likelihood-of-stop-comparison-v3.py
+++ b/nc/notebooks/2025-11-likelihood-of-stops-comparison/likelihood-of-stop-comparison-v3.py
@@ -49,6 +49,7 @@ with app.setup(hide_code=True):
 
     from nc.models import AgencyLikelihoodStatus, DriverRace  # noqa
     from nc.views.likelihood import (
+        active_small_population_agencies,
         available_likelihood_years,
         excluded_police_agencies,
         likelihood_comparison,
@@ -119,6 +120,7 @@ def filters(mo):
 
 @app.cell(hide_code=True)
 def sidebar(
+    include_small_pop_toggle,
     layout_toggle,
     min_stops_slider,
     mo,
@@ -138,6 +140,7 @@ def sidebar(
                 layout_toggle,
                 scale_toggle,
                 min_stops_slider,
+                include_small_pop_toggle,
             ]
         )
     )
@@ -387,7 +390,10 @@ def police_agency_disparity_map_section_header(mo):
     - **Red**: ≥ 3.0 — Severe disparity
 
     Use the controls below to switch between flat dots and bubbles, choose what
-    the bubble size represents, and filter out low-volume agencies.
+    the bubble size represents, and filter out low-volume agencies. Toggle
+    "Include smaller departments (< 10,000 population)" to overlay agencies that
+    voluntarily report despite being below the population threshold; they appear
+    as hollow markers to distinguish them from active agencies.
     """)
     return
 
@@ -412,12 +418,22 @@ def disparity_map_controls(mo):
         value=50,
         label="Minimum stops (selected race)",
     )
-    return layout_toggle, min_stops_slider, scale_toggle
+    include_small_pop_toggle = mo.ui.switch(
+        value=False,
+        label="Include smaller departments (< 10,000 population)",
+    )
+    return (
+        include_small_pop_toggle,
+        layout_toggle,
+        min_stops_slider,
+        scale_toggle,
+    )
 
 
 @app.cell
 def police_agency_disparity_map(
     df_agency: pd.DataFrame,
+    include_small_pop_toggle,
     layout_toggle,
     min_stops_slider,
     mo,
@@ -446,6 +462,7 @@ def police_agency_disparity_map(
 
     _map_race = race_dropdown.value or DriverRace.BLACK.label
     _min_stops = min_stops_slider.value
+    _show_small_pop = include_small_pop_toggle.value
 
     # Filter to non-sheriff police agencies with coordinates
     _police_df = df_agency[
@@ -461,7 +478,29 @@ def police_agency_disparity_map(
         pd.to_numeric(_police_df["total_stops"], errors="coerce").fillna(0).astype(int)
     )
 
-    if _police_df.empty:
+    # Optionally build sub-threshold (< 10,000 population) agencies to overlay.
+    # The same minimum-stops filter is applied for consistency with active agencies.
+    _small_pop_df = pd.DataFrame()
+    if _show_small_pop:
+        _excluded = excluded_police_agencies(year=selected_year, race=_map_race)
+        if not _excluded.empty:
+            _small_pop_df = _excluded[
+                (_excluded["status"] == AgencyLikelihoodStatus.SMALL_POPULATION)
+                & _excluded["latitude"].notna()
+                & _excluded["longitude"].notna()
+            ].copy()
+            _small_pop_df["stops"] = (
+                pd.to_numeric(_small_pop_df["stops"], errors="coerce").fillna(0).astype(int)
+            )
+            _small_pop_df["total_stops"] = (
+                pd.to_numeric(_small_pop_df["total_stops"], errors="coerce").fillna(0).astype(int)
+            )
+            _small_pop_df = _small_pop_df[_small_pop_df["stops"] >= _min_stops]
+            _small_pop_df["disparity_category"] = _small_pop_df["times_likely"].apply(
+                _disparity_category
+            )
+
+    if _police_df.empty and _small_pop_df.empty:
         mo.stop(
             True,
             mo.callout(mo.md("No police agencies found with the current filters."), kind="warn"),
@@ -514,6 +553,33 @@ def police_agency_disparity_map(
         _fig_disparity.update_traces(marker_size=8)
     _fig_disparity.update_layout(height=650, margin={"r": 0, "t": 40, "l": 0, "b": 0})
 
+    # Overlay sub-threshold agencies as hollow markers so voluntary reporters are
+    # visually distinct from active agencies while sharing the disparity colors.
+    if not _small_pop_df.empty:
+        _marker_colors = _small_pop_df["disparity_category"].map(_DISPARITY_COLORS)
+        _fig_disparity.add_trace(
+            go.Scattergeo(
+                lat=_small_pop_df["latitude"],
+                lon=_small_pop_df["longitude"],
+                mode="markers",
+                name="< 10,000 population",
+                text=_small_pop_df["group_name"],
+                customdata=_small_pop_df[["times_likely", "stops", "total_stops"]].values,
+                hovertemplate=(
+                    "<b>%{text}</b><br>"
+                    "Times likely: %{customdata[0]:.2f}<br>"
+                    f"Stops ({_map_race}): %{{customdata[1]}}<br>"
+                    "Total stops: %{customdata[2]}<br>"
+                    "<i>&lt; 10,000 population</i><extra></extra>"
+                ),
+                marker=dict(
+                    size=10,
+                    color="rgba(255, 255, 255, 0)",
+                    line=dict(width=2, color=_marker_colors),
+                ),
+            )
+        )
+
     _table_cols = [
         "group_name",
         "driver_race",
@@ -533,6 +599,13 @@ def police_agency_disparity_map(
     # Append excluded agencies (below population threshold) from matview
     _excluded_matview = excluded_police_agencies(year=selected_year, race=_map_race)
     if not _excluded_matview.empty:
+        _plotted_ids = set(_small_pop_df["group_id"]) if not _small_pop_df.empty else set()
+
+        def _exclusion_label(row):
+            if row["group_id"] in _plotted_ids:
+                return "Shown on map (< 10,000 population)"
+            return AgencyLikelihoodStatus(row["status"]).label
+
         _excluded_rows = pd.DataFrame(
             {col: pd.NA for col in _table_cols},
             index=range(len(_excluded_matview)),
@@ -544,9 +617,9 @@ def police_agency_disparity_map(
         _excluded_rows["total_stops"] = _excluded_matview["total_stops"].values
         _excluded_rows["stop_rate"] = _excluded_matview["stop_rate"].round(4).values
         _excluded_rows["times_likely"] = _excluded_matview["times_likely"].round(2).values
-        _excluded_rows["exclusion_reason"] = (
-            _excluded_matview["status"].map(lambda s: AgencyLikelihoodStatus(s).label).values
-        )
+        _excluded_rows["exclusion_reason"] = _excluded_matview.apply(
+            _exclusion_label, axis=1
+        ).values
         _disparity_table_df = pd.concat([_disparity_table_df, _excluded_rows], ignore_index=True)
 
     # Append agencies with no census profile
@@ -561,6 +634,50 @@ def police_agency_disparity_map(
         _disparity_table_df = pd.concat([_disparity_table_df, _no_census_rows], ignore_index=True)
 
     mo.vstack([mo.ui.plotly(_fig_disparity), _disparity_table_df])
+    return
+
+
+@app.cell(hide_code=True)
+def sub_threshold_audit_section_header(mo):
+    """Render the section header for the sub-threshold reporting audit."""
+    mo.md(r"""
+    ## Audit: Sub-Threshold Agencies Actively Reporting
+
+    Police departments below the 10,000-population threshold
+    (`status = small_population`) are excluded from the disparity map by default.
+    Some of these smaller departments voluntarily submit traffic stop data.
+
+    The table below lists non-sheriff agencies under the threshold that recorded
+    at least one stop in the most recent data year, with each agency's total
+    population and total stops. Use it to gauge the scope and data quality of
+    voluntary reporting before investing in front-end visibility.
+    """)
+    return
+
+
+@app.cell
+def sub_threshold_audit(mo):
+    """List sub-threshold agencies that are actively reporting stop data."""
+    _audit_year = available_likelihood_years()[0]
+    _audit_df = active_small_population_agencies(year=_audit_year)
+
+    _display_df = _audit_df.rename(
+        columns={
+            "group_name": "Agency",
+            "total_population": "Total population",
+            "total_stops": "Total stops",
+        }
+    )[["Agency", "Total population", "Total stops"]]
+
+    mo.vstack(
+        [
+            mo.md(
+                f"**{len(_audit_df)}** sub-threshold non-sheriff agencies actively "
+                f"reported traffic stops in **{_audit_year}**."
+            ),
+            mo.ui.table(_display_df, selection=None),
+        ]
+    )
     return
 
 

--- a/nc/notebooks/2025-11-likelihood-of-stops-comparison/likelihood-of-stop-comparison-v3.py
+++ b/nc/notebooks/2025-11-likelihood-of-stops-comparison/likelihood-of-stop-comparison-v3.py
@@ -123,8 +123,6 @@ def filters(mo):
 @app.cell(hide_code=True)
 def sidebar(
     include_small_pop_toggle,
-    layout_toggle,
-    min_stops_slider,
     mo,
     race_dropdown,
     scale_toggle,
@@ -139,9 +137,7 @@ def sidebar(
                 race_dropdown,
                 mo.md("---"),
                 mo.md("**Agency Disparity Map**"),
-                layout_toggle,
                 scale_toggle,
-                min_stops_slider,
                 include_small_pop_toggle,
             ]
         )
@@ -480,22 +476,10 @@ def police_agency_disparity_map_section_header(mo):
 @app.cell(hide_code=True)
 def disparity_map_controls(mo):
     """Build controls for the police agency disparity map."""
-    layout_toggle = mo.ui.radio(
-        options=["Flat dots", "Bubbles"],
-        value="Bubbles",
-        label="Layout",
-    )
     scale_toggle = mo.ui.radio(
         options=["Total Traffic Stops", "Stops of Selected Race"],
         value="Total Traffic Stops",
         label="Bubble size",
-    )
-    min_stops_slider = mo.ui.slider(
-        start=0,
-        stop=500,
-        step=25,
-        value=100,
-        label="Minimum stops (selected race)",
     )
     include_small_pop_toggle = mo.ui.switch(
         value=True,
@@ -503,8 +487,6 @@ def disparity_map_controls(mo):
     )
     return (
         include_small_pop_toggle,
-        layout_toggle,
-        min_stops_slider,
         scale_toggle,
     )
 
@@ -513,8 +495,6 @@ def disparity_map_controls(mo):
 def police_agency_disparity_map(
     df_agency: pd.DataFrame,
     include_small_pop_toggle,
-    layout_toggle,
-    min_stops_slider,
     mo,
     race_dropdown,
     scale_toggle,
@@ -540,7 +520,7 @@ def police_agency_disparity_map(
         return "≥ 3.0 (Severe)"
 
     _map_race = race_dropdown.value or DriverRace.BLACK.label
-    _min_stops = min_stops_slider.value
+    _min_stops = 100
     _show_small_pop = include_small_pop_toggle.value
 
     # Filter to non-sheriff police agencies with coordinates
@@ -587,7 +567,6 @@ def police_agency_disparity_map(
 
     _police_df["disparity_category"] = _police_df["times_likely"].apply(_disparity_category)
 
-    _use_bubbles = layout_toggle.value == "Bubbles"
     _size_col = "total_stops" if scale_toggle.value == "Total Traffic Stops" else "stops"
 
     _scatter_kwargs = dict(
@@ -612,9 +591,8 @@ def police_agency_disparity_map(
             "total_stops": "Total stops",
         },
     )
-    if _use_bubbles:
-        _scatter_kwargs["size"] = _size_col
-        _scatter_kwargs["size_max"] = 30
+    _scatter_kwargs["size"] = _size_col
+    _scatter_kwargs["size_max"] = 30
 
     _fig_disparity = px.scatter_geo(**_scatter_kwargs)
     _fig_disparity.update_geos(
@@ -628,8 +606,6 @@ def police_agency_disparity_map(
         showsubunits=True,
         subunitcolor="#cccccc",
     )
-    if not _use_bubbles:
-        _fig_disparity.update_traces(marker_size=8)
     _fig_disparity.update_layout(height=650, margin={"r": 0, "t": 40, "l": 0, "b": 0})
 
     # Overlay sub-threshold agencies as hollow markers so voluntary reporters are

--- a/nc/notebooks/2025-11-likelihood-of-stops-comparison/likelihood-of-stop-comparison-v3.py
+++ b/nc/notebooks/2025-11-likelihood-of-stops-comparison/likelihood-of-stop-comparison-v3.py
@@ -464,11 +464,12 @@ def police_agency_disparity_map_section_header(mo):
     - **Orange**: 2.0 – 3.0 — High disparity
     - **Red**: ≥ 3.0 — Severe disparity
 
-    Use the controls below to switch between flat dots and bubbles, choose what
-    the bubble size represents, and filter out low-volume agencies. Toggle
-    "Include smaller departments (< 10,000 population)" to overlay agencies that
-    voluntarily report despite being below the population threshold; they appear
-    as hollow markers to distinguish them from active agencies.
+    Use the control below to choose what the bubble size represents. Agencies
+    with fewer than 100 stops (for the selected race) are omitted from the map.
+
+    Smaller departments (< 10,000 population) that voluntarily report are shown
+    by default as hollow markers to distinguish them from active agencies. Turn
+    off "Include smaller departments (< 10,000 population)" to hide them.
     """)
     return
 
@@ -485,10 +486,7 @@ def disparity_map_controls(mo):
         value=True,
         label="Include smaller departments (< 10,000 population)",
     )
-    return (
-        include_small_pop_toggle,
-        scale_toggle,
-    )
+    return include_small_pop_toggle, scale_toggle
 
 
 @app.cell
@@ -717,7 +715,15 @@ def sub_threshold_audit(mo, selected_year):
     # active_small_population_agencies() needs a concrete year. When the sidebar
     # Year filter is set to "All" (selected_year is None), fall back to the most
     # recent available year so the audit still renders.
-    _audit_year = selected_year if selected_year else available_likelihood_years()[0]
+    _years = available_likelihood_years()
+    _audit_year = selected_year if selected_year else (_years[0] if _years else None)
+    mo.stop(
+        _audit_year is None,
+        mo.callout(
+            mo.md("No census years are available, so the sub-threshold audit cannot run."),
+            kind="warn",
+        ),
+    )
     _audit_df = active_small_population_agencies(year=_audit_year)
 
     _display_df = _audit_df.rename(

--- a/nc/notebooks/2025-11-likelihood-of-stops-comparison/likelihood-of-stop-comparison-v3.py
+++ b/nc/notebooks/2025-11-likelihood-of-stops-comparison/likelihood-of-stop-comparison-v3.py
@@ -482,7 +482,7 @@ def disparity_map_controls(mo):
     """Build controls for the police agency disparity map."""
     layout_toggle = mo.ui.radio(
         options=["Flat dots", "Bubbles"],
-        value="Flat dots",
+        value="Bubbles",
         label="Layout",
     )
     scale_toggle = mo.ui.radio(
@@ -494,11 +494,11 @@ def disparity_map_controls(mo):
         start=0,
         stop=500,
         step=25,
-        value=50,
+        value=100,
         label="Minimum stops (selected race)",
     )
     include_small_pop_toggle = mo.ui.switch(
-        value=False,
+        value=True,
         label="Include smaller departments (< 10,000 population)",
     )
     return (
@@ -654,7 +654,7 @@ def police_agency_disparity_map(
                 marker=dict(
                     size=10,
                     color="rgba(255, 255, 255, 0)",
-                    line=dict(width=2, color="black"),
+                    line=dict(width=2, color="#777777"),
                 ),
             )
         )

--- a/nc/tests/test_likelihood_comparison.py
+++ b/nc/tests/test_likelihood_comparison.py
@@ -221,6 +221,32 @@ class TestLikelihoodComparison:
         assert not small_rows.empty
         assert (small_rows["status"] == AgencyLikelihoodStatus.SMALL_POPULATION).all()
 
+    def test_query_kwarg_filters_at_db_level(self, durham_agency, year_2023):
+        """A `query` Q object applies DB-level filtering on both branches."""
+        _create_stops_and_census(durham_agency, year_2023)
+
+        from django.db.models import Q
+
+        # Matching group_name returns rows; non-matching excludes everything.
+        year_df = likelihood_comparison(
+            level="agency", year=2023, query=Q(group_name__icontains="Durham")
+        )
+        assert not year_df.empty
+        assert set(year_df["group_name"]) == {"Durham Police Department"}
+
+        assert likelihood_comparison(
+            level="agency", year=2023, query=Q(group_name__icontains="Nonexistent")
+        ).empty
+
+        # The no-year branch honors the query too and still computes baseline.
+        no_year_df = likelihood_comparison(level="agency", query=Q(group_name__icontains="Durham"))
+        assert not no_year_df.empty
+        assert set(no_year_df["group_name"]) == {"Durham Police Department"}
+        white = no_year_df[no_year_df["driver_race"] == "White"]
+        assert not white.empty
+        for _, row in white.iterrows():
+            assert row["times_likely"] == pytest.approx(1.0)
+
 
 @pytest.mark.django_db(databases=["default", "traffic_stops_nc"])
 class TestActiveSmallPopulationAgencies:

--- a/nc/tests/test_likelihood_comparison.py
+++ b/nc/tests/test_likelihood_comparison.py
@@ -13,6 +13,7 @@ from nc.models import (
 from nc.tests.factories import AgencyFactory, NCCensusProfileFactory, PersonFactory
 from nc.tests.urls import reverse_querystring
 from nc.views.likelihood import (
+    active_small_population_agencies,
     available_likelihood_years,
     excluded_police_agencies,
     likelihood_comparison,
@@ -219,6 +220,78 @@ class TestLikelihoodComparison:
         small_rows = df_all[df_all["group_id"] == str(small_agency.id)]
         assert not small_rows.empty
         assert (small_rows["status"] == AgencyLikelihoodStatus.SMALL_POPULATION).all()
+
+
+@pytest.mark.django_db(databases=["default", "traffic_stops_nc"])
+class TestActiveSmallPopulationAgencies:
+    """Audit helper for sub-threshold agencies actively reporting stops (issue #411)."""
+
+    def _make_small_agency(self, name, acs_id, year_date, black_stops=10, white_stops=20):
+        agency = AgencyFactory(name=name, census_profile_id=acs_id)
+        NCCensusProfileFactory(
+            acs_id=acs_id,
+            race="Black",
+            population=500,
+            population_total=5000,  # below 10k threshold
+            year=year_date.year,
+        )
+        NCCensusProfileFactory(
+            acs_id=acs_id,
+            race="White",
+            population=2000,
+            population_total=5000,
+            year=year_date.year,
+        )
+        if black_stops:
+            PersonFactory.create_batch(
+                black_stops,
+                race=DriverRace.BLACK,
+                ethnicity=DriverEthnicity.NON_HISPANIC,
+                stop__agency=agency,
+                stop__date=year_date,
+            )
+        if white_stops:
+            PersonFactory.create_batch(
+                white_stops,
+                race=DriverRace.WHITE,
+                ethnicity=DriverEthnicity.NON_HISPANIC,
+                stop__agency=agency,
+                stop__date=year_date,
+            )
+        return agency
+
+    def test_lists_sub_threshold_reporting_agency(self, year_2023):
+        agency = self._make_small_agency("Tiny Town PD", "1600000US0000001", year_2023)
+        StopSummary.refresh()
+        LikelihoodOfStopSummary.refresh()
+
+        df = active_small_population_agencies(year=2023)
+        assert list(df.columns) == [
+            "group_id",
+            "group_name",
+            "total_population",
+            "total_stops",
+        ]
+        rows = df[df["group_id"] == str(agency.id)]
+        assert len(rows) == 1  # one agency-level row despite per-race view rows
+        assert rows.iloc[0]["total_population"] == 5000
+        assert rows.iloc[0]["total_stops"] == 30
+
+    def test_excludes_sheriff_agencies(self, year_2023):
+        self._make_small_agency("Tiny County Sheriff", "1600000US0000002", year_2023)
+        StopSummary.refresh()
+        LikelihoodOfStopSummary.refresh()
+
+        df = active_small_population_agencies(year=2023)
+        assert df.empty or not df["group_name"].str.contains("Sheriff").any()
+
+    def test_defaults_to_most_recent_year(self, year_2023):
+        agency = self._make_small_agency("Tiny Town PD", "1600000US0000001", year_2023)
+        StopSummary.refresh()
+        LikelihoodOfStopSummary.refresh()
+
+        df = active_small_population_agencies()
+        assert str(agency.id) in df["group_id"].values
 
 
 @pytest.mark.django_db(databases=["default", "traffic_stops_nc"])

--- a/nc/views/likelihood.py
+++ b/nc/views/likelihood.py
@@ -2,7 +2,7 @@ import django_filters
 import numpy as np
 import pandas as pd
 
-from django.db.models import Avg, Min, Sum
+from django.db.models import Avg, Min, Q, Sum
 from django.db.models.functions import ExtractYear
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -202,7 +202,10 @@ def available_likelihood_years() -> list[int]:
 
 
 def likelihood_comparison(
-    level="agency", year=None, status: str | None = AgencyLikelihoodStatus.ACTIVE
+    level="agency",
+    year=None,
+    status: str | None = AgencyLikelihoodStatus.ACTIVE,
+    query: Q | None = None,
 ) -> pd.DataFrame:
     """
     Query LikelihoodOfStopSummary view for comparative stop likelihood data.
@@ -213,6 +216,13 @@ def likelihood_comparison(
             ``available_likelihood_years()``, returns an empty DataFrame.
         status: filter to rows with this status value. Pass ``None`` to return
             all rows regardless of status. Defaults to ``AgencyLikelihoodStatus.ACTIVE``.
+        query: optional ``Q`` object applied to the base queryset for additional
+            DB-level filtering (e.g. ``~Q(group_name__icontains="Sheriff")``). It is
+            applied to both the year and no-year branches. Do **not** filter on
+            ``driver_race`` here for the no-year path: that branch recomputes
+            ``baseline_rate`` by merging each group's White row, so removing White
+            rows at the DB level would break the baseline calculation. Filter race
+            in Pandas after this function returns instead.
 
     Returns:
         DataFrame with columns: level, group_id, group_name, census_profile_id,
@@ -222,45 +232,47 @@ def likelihood_comparison(
     qs = LikelihoodOfStopSummary.objects.filter(level=level)
     if status is not None:
         qs = qs.filter(status=status)
+    if query is not None:
+        qs = qs.filter(query)
     if year is not None:
         if int(year) not in available_likelihood_years():
             return pd.DataFrame()
-        df = pd.DataFrame(
-            qs.filter(year=year).values(
-                "level",
-                "group_id",
-                "group_name",
-                "census_profile_id",
-                "year",
-                "driver_race",
-                "population",
-                "total_population",
-                "stops",
-                "total_stops",
-                "stop_rate",
-                "baseline_rate",
-                "stop_rate_ratio",
-                "times_likely",
-                "status",
-                "latitude",
-                "longitude",
-            )
+        qs = qs.filter(year=year).values(
+            "level",
+            "group_id",
+            "group_name",
+            "census_profile_id",
+            "year",
+            "driver_race",
+            "population",
+            "total_population",
+            "stops",
+            "total_stops",
+            "stop_rate",
+            "baseline_rate",
+            "stop_rate_ratio",
+            "times_likely",
+            "status",
+            "latitude",
+            "longitude",
         )
+        df = pd.DataFrame(qs, columns=list(qs.query.values_select))
     else:
         # Aggregate across all years in the database rather than fetching every
         # per-year row and grouping in Python. This avoids transferring millions
         # of rows over the wire.
+        qs = qs.values(
+            "level", "group_id", "group_name", "census_profile_id", "driver_race", "status"
+        ).annotate(
+            population=Avg("population"),
+            total_population=Avg("total_population"),
+            stops=Avg("stops"),
+            total_stops=Avg("total_stops"),
+            latitude=Min("latitude"),
+            longitude=Min("longitude"),
+        )
         df = pd.DataFrame(
-            qs.values(
-                "level", "group_id", "group_name", "census_profile_id", "driver_race", "status"
-            ).annotate(
-                population=Avg("population"),
-                total_population=Avg("total_population"),
-                stops=Avg("stops"),
-                total_stops=Avg("total_stops"),
-                latitude=Min("latitude"),
-                longitude=Min("longitude"),
-            )
+            qs, columns=list(qs.query.values_select) + list(qs.query.annotation_select)
         )
     if df.empty:
         return df
@@ -331,15 +343,17 @@ def excluded_police_agencies(year: int = None, race: str = None) -> pd.DataFrame
     Returns:
         DataFrame with the same columns as likelihood_comparison() plus status.
     """
-    df = likelihood_comparison(level="agency", year=year, status=None)
+    df = likelihood_comparison(
+        level="agency",
+        year=year,
+        status=None,
+        query=~Q(group_name__icontains="Sheriff") & ~Q(status=AgencyLikelihoodStatus.ACTIVE),
+    )
     if df.empty:
         return df
-    mask = ~df["group_name"].str.contains("Sheriff", case=False) & (
-        df["status"] != AgencyLikelihoodStatus.ACTIVE
-    )
     if race:
-        mask = mask & (df["driver_race"] == race)
-    return df[mask].reset_index(drop=True)
+        df = df[df["driver_race"] == race]
+    return df.reset_index(drop=True)
 
 
 def active_small_population_agencies(year: int = None) -> pd.DataFrame:
@@ -368,18 +382,20 @@ def active_small_population_agencies(year: int = None) -> pd.DataFrame:
             )
         year = years[0]
 
-    df = excluded_police_agencies(year=year)
+    df = likelihood_comparison(
+        level="agency",
+        year=year,
+        status=None,
+        query=~Q(group_name__icontains="Sheriff")
+        & Q(status=AgencyLikelihoodStatus.SMALL_POPULATION),
+    )
     if df.empty:
-        return pd.DataFrame(columns=["group_id", "group_name", "total_population", "total_stops"])
-
-    small_pop = df[df["status"] == AgencyLikelihoodStatus.SMALL_POPULATION]
-    if small_pop.empty:
         return pd.DataFrame(columns=["group_id", "group_name", "total_population", "total_stops"])
 
     # Collapse per-race rows to one agency-level row (population/stop totals are
     # agency-level and repeated across races).
     agencies = (
-        small_pop.groupby(["group_id", "group_name"], as_index=False)
+        df.groupby(["group_id", "group_name"], as_index=False)
         .agg(total_population=("total_population", "max"), total_stops=("total_stops", "max"))
         .astype({"total_population": int, "total_stops": int})
     )

--- a/nc/views/likelihood.py
+++ b/nc/views/likelihood.py
@@ -342,6 +342,51 @@ def excluded_police_agencies(year: int = None, race: str = None) -> pd.DataFrame
     return df[mask].reset_index(drop=True)
 
 
+def active_small_population_agencies(year: int = None) -> pd.DataFrame:
+    """
+    Audit helper: non-sheriff agencies below the 10,000-population threshold
+    (status = small_population) that are actively submitting stop data.
+
+    Unlike ``excluded_police_agencies()``, this excludes agencies flagged only
+    for ``small_race_population`` (a different exclusion reason) and keeps a
+    single agency-level row (the underlying view is per-race). Only agencies
+    with at least one recorded stop in the target year are returned.
+
+    Args:
+        year: year to audit. Defaults to the most recent census year from
+            ``available_likelihood_years()``.
+
+    Returns:
+        DataFrame sorted by ``total_stops`` descending with columns:
+        group_id, group_name, total_population, total_stops.
+    """
+    if year is None:
+        years = available_likelihood_years()
+        if not years:
+            return pd.DataFrame(
+                columns=["group_id", "group_name", "total_population", "total_stops"]
+            )
+        year = years[0]
+
+    df = excluded_police_agencies(year=year)
+    if df.empty:
+        return pd.DataFrame(columns=["group_id", "group_name", "total_population", "total_stops"])
+
+    small_pop = df[df["status"] == AgencyLikelihoodStatus.SMALL_POPULATION]
+    if small_pop.empty:
+        return pd.DataFrame(columns=["group_id", "group_name", "total_population", "total_stops"])
+
+    # Collapse per-race rows to one agency-level row (population/stop totals are
+    # agency-level and repeated across races).
+    agencies = (
+        small_pop.groupby(["group_id", "group_name"], as_index=False)
+        .agg(total_population=("total_population", "max"), total_stops=("total_stops", "max"))
+        .astype({"total_population": int, "total_stops": int})
+    )
+    agencies = agencies[agencies["total_stops"] > 0]
+    return agencies.sort_values("total_stops", ascending=False).reset_index(drop=True)
+
+
 def no_census_agencies() -> pd.DataFrame:
     """
     Return non-sheriff police agencies with no census profile.


### PR DESCRIPTION
This pull request implements features for issues #410 and #411 related to sub-threshold agencies in the Traffic Stops project.

### Changes Made:
- **Issue #411**: 
  - Introduced a new helper function `active_small_population_agencies(year=None)` in `likelihood.py` to filter and return active small population agencies.
  - Added an audit section in the notebook `likelihood-of-stop-comparison-v3.py` that utilizes the new helper to display a count and table of sub-threshold reporters, confirming 78 agencies.

- **Issue #410**: 
  - Implemented an opt-in toggle labeled **"Include smaller departments (< 10,000 population)"** in the disparity map controls.
  - When enabled, the map overlays small population agencies with a distinct visual representation and updates the exclusion table accordingly.